### PR TITLE
Fix pre-release bump

### DIFF
--- a/crates/seal/tests/it/bump/version_calculation.rs
+++ b/crates/seal/tests/it/bump/version_calculation.rs
@@ -879,15 +879,83 @@ confirm = false
         .write_str(r#"version = "1.2.3""#)
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("alpha"), @r"
-    success: false
-    exit_code: 2
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("alpha"), @r#"
+    success: true
+    exit_code: 0
     ----- stdout -----
+    Bumping version from 1.2.3 to 1.2.3-alpha.0
+
+    Preview of changes:
+    -------------------
+
+    diff --git a/VERSION b/VERSION
+    --- a/VERSION
+    +++ b/VERSION
+    @@ -1 +1 @@
+    -version = "1.2.3"
+    +version = "1.2.3-alpha.0"
+
+    Commands to be executed:
+      git checkout -b release/1.2.3-alpha.0
+      # Update version files
+      # Update seal.toml
+      git add -A
+      git commit -m "Release 1.2.3-alpha.0"
+
+    Creating branch: release/1.2.3-alpha.0
+    Updating version files...
+    Updating seal.toml...
+    Committing changes...
+    Successfully bumped to 1.2.3-alpha.0
 
     ----- stderr -----
-    error: Failed to calculate new version from '1.2.3' with bump 'alpha'
-      Caused by: invalid version bump: 'Cannot bump prerelease on a stable version'. Expected 'major', 'minor', 'patch', 'alpha', 'beta', 'rc', combinations like 'major-alpha', or a semantic version like '1.2.3'
-    ");
+    "#);
+
+    insta::assert_snapshot!(context.git_current_branch(), @r"release/1.2.3-alpha.0");
+
+    insta::assert_snapshot!(context.git_last_commit_message(), @r"Release 1.2.3-alpha.0");
+
+    insta::assert_snapshot!(context.read_file("VERSION"), @r###"version = "1.2.3-alpha.0""###);
+
+    context.merge_current_branch_and_checkout_main();
+
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("alpha"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Bumping version from 1.2.3-alpha.0 to 1.2.3-alpha.1
+
+    Preview of changes:
+    -------------------
+
+    diff --git a/VERSION b/VERSION
+    --- a/VERSION
+    +++ b/VERSION
+    @@ -1 +1 @@
+    -version = "1.2.3-alpha.0"
+    +version = "1.2.3-alpha.1"
+
+    Commands to be executed:
+      git checkout -b release/1.2.3-alpha.1
+      # Update version files
+      # Update seal.toml
+      git add -A
+      git commit -m "Release 1.2.3-alpha.1"
+
+    Creating branch: release/1.2.3-alpha.1
+    Updating version files...
+    Updating seal.toml...
+    Committing changes...
+    Successfully bumped to 1.2.3-alpha.1
+
+    ----- stderr -----
+    "#);
+
+    insta::assert_snapshot!(context.git_current_branch(), @r"release/1.2.3-alpha.1");
+
+    insta::assert_snapshot!(context.git_last_commit_message(), @r"Release 1.2.3-alpha.1");
+
+    insta::assert_snapshot!(context.read_file("VERSION"), @r#"version = "1.2.3-alpha.1""#);
 }
 
 #[test]

--- a/crates/seal/tests/it/common/mod.rs
+++ b/crates/seal/tests/it/common/mod.rs
@@ -217,6 +217,33 @@ current-version = "{version}"
         output.status.success()
     }
 
+    pub fn merge_current_branch_and_checkout_main(&self) {
+        let current_branch = self.git_current_branch();
+
+        assert!(self.git_branch_exists("main"), "Main branch does not exist");
+
+        assert!(
+            current_branch != "main",
+            "Cannot merge current branch with itself"
+        );
+
+        let output = std::process::Command::new("git")
+            .args(["checkout", "main"])
+            .current_dir(self.root.path())
+            .output()
+            .expect("Failed to checkout main");
+
+        assert!(output.status.success(), "Failed to checkout main");
+
+        let output = std::process::Command::new("git")
+            .args(["merge", &current_branch])
+            .current_dir(self.root.path())
+            .output()
+            .expect("Failed to merge current branch");
+
+        assert!(output.status.success(), "Failed to merge current branch");
+    }
+
     /// Read a file and return its contents as a string.
     pub fn read_file(&self, path: &str) -> String {
         std::fs::read_to_string(self.root.join(path))

--- a/crates/seal_bump/src/lib.rs
+++ b/crates/seal_bump/src/lib.rs
@@ -204,9 +204,7 @@ fn extract_prerelease_number(
     expected_type: PreReleaseType,
 ) -> Result<u64, VersionBumpError> {
     if pre.is_empty() {
-        return Err(VersionBumpError::InvalidBump(
-            "Cannot bump prerelease on a stable version".to_string(),
-        ));
+        return Ok(0);
     }
 
     let parts: Vec<&str> = pre.as_str().split('.').collect();
@@ -218,6 +216,7 @@ fn extract_prerelease_number(
     }
 
     let current_type = parts[0];
+
     if current_type != expected_type.to_string() {
         return Err(VersionBumpError::InvalidBump(format!(
             "Cannot bump {expected_type} prerelease on a {current_type} version"
@@ -546,18 +545,6 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("Cannot bump beta prerelease on a alpha version")
-        );
-    }
-
-    #[test]
-    fn test_calculate_version_prerelease_on_stable() {
-        let result = calculate_version("1.2.3", &VersionBump::PreRelease(PreReleaseType::Alpha));
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Cannot bump prerelease on a stable version")
         );
     }
 

--- a/seal.toml
+++ b/seal.toml
@@ -8,3 +8,9 @@ commit-message = "Release v{version}"
 branch-name = "release/v{version}"
 
 tag-format = "v{version}"
+
+push = true
+
+create_pr = true
+
+confirm = true


### PR DESCRIPTION
## Summary

Previously we didn't allow users to bump pre release from stable, i think this is wrong.

## Test Plan

We add tests that we can bump stable -> pre release -> pre release.
