### PR TITLE
Support ignoring contributors in changelog

### DIFF
--- a/crates/seal_project/src/config.rs
+++ b/crates/seal_project/src/config.rs
@@ -328,6 +328,17 @@ pub struct ChangelogConfig {
     )]
     pub ignore_labels: Option<Vec<String>>,
 
+    /// Contributors to ignore when generating changelog.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[field(
+        default = "[]",
+        value_type = "list",
+        example = r#"
+        ignore-contributors = ["dependabot[bot]"]
+        "#
+    )]
+    pub ignore_contributors: Option<Vec<String>>,
+
     /// Mapping of section names to labels.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[field(

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -41,6 +41,26 @@ Template for the changelog heading. Must contain {version} placeholder.
 
 ---
 
+#### [`ignore-contributors`](#changelog_ignore-contributors)
+<span id="ignore-contributors"></span>
+
+Contributors to ignore when generating changelog.
+
+**Default value**: `[]`
+
+**Type**: `list`
+
+**Example usage**:
+
+=== "seal.toml"
+
+    ```toml
+    [changelog]
+    ignore-contributors = ["dependabot[bot]"]
+    ```
+
+---
+
 #### [`ignore-labels`](#changelog_ignore-labels)
 <span id="ignore-labels"></span>
 

--- a/seal.toml
+++ b/seal.toml
@@ -8,11 +8,21 @@ version-files = [
 ]
 
 commit-message = "Release v{version}"
-
 branch-name = "release/v{version}"
-
 push = true
-
 create-pr = true
-
 confirm = true
+
+[changelog.section-labels]
+"Bug Fixes" = ["bug"]
+"Changelog " = ["changelog"]
+"Configuration" = ["configuration"]
+"New Features" = ["enhancement"]
+"CLI" = ["cli"]
+"Documentation" = ["documentation"]
+
+[changelog]
+ignore-contributors = ["dependabot[bot]"]
+ignore-labels = ["internal", "ci", "duplicate", "rust", "wontfix", "needs-decision"]
+include-contributors = true
+changelog-heading = "{version}"


### PR DESCRIPTION
## Summary

Often bots like dependabot are contributing via PRs, we should allow users to ignore them.
