### PR TITLE
Add uv MIT license

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,16 @@ We do not (yet) have support for installation from other sources, like PyPI or c
 ## Documentation
 
 seal's documentation is available at [matthewmckee4.github.io/seal](https://matthewmckee4.github.io/seal/)
+
+## Acknowledgements
+
+I'd like to thank the [Astral team](https://github.com/astral-sh) for all of their contributions to the Rust ecosystem.
+
+Particularly, the projects [uv](https://github.com/astral-sh/uv) and [ruff](https://github.com/astral-sh/ruff).
+
+## License
+
+Seal is licensed under the MIT License.
+
+We also include the [uv MIT license at](https://github.com/MatthewMckee4/seal/blob/main/licenses/astral.LICENSE-MIT), as we often
+take inspiration or code snippets from the [uv](https://github.com/astral-sh/uv) repository.

--- a/crates/seal/src/printer.rs
+++ b/crates/seal/src/printer.rs
@@ -1,25 +1,3 @@
-// MIT License
-//
-// Copyright (c) 2023 Astral Software Inc.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
 use anstream::{eprint, print};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/licenses/README.md
+++ b/licenses/README.md
@@ -1,0 +1,3 @@
+# Licenses
+
+Like mentioned in the readme, we include the uv MIT license here as we often take code from it.

--- a/licenses/astral.LICENSE-MIT
+++ b/licenses/astral.LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Astral Software Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

Add uv MIT license in `licenses/` folder as we must acknowledge their work.
