### PR TITLE
Support pre commit commands

### DIFF
--- a/crates/seal/src/commands/bump.rs
+++ b/crates/seal/src/commands/bump.rs
@@ -138,6 +138,14 @@ pub async fn bump(args: &BumpArgs, printer: Printer) -> Result<ExitStatus> {
 
     if let Some(message) = &commit_message {
         commands.push(CommandWrapper::git_add_all());
+
+        if let Some(pre_commit_cmds) = release_config.pre_commit_commands.as_ref() {
+            for cmd in pre_commit_cmds {
+                commands.push(CommandWrapper::custom(cmd));
+            }
+            commands.push(CommandWrapper::git_add_all());
+        }
+
         commands.push(CommandWrapper::git_commit(message));
     }
 

--- a/crates/seal/tests/it/validate/config.rs
+++ b/crates/seal/tests/it/validate/config.rs
@@ -348,7 +348,7 @@ unknown-field = "value"
       |
     3 | unknown-field = "value"
       | ^^^^^^^^^^^^^
-    unknown field `unknown-field`, expected one of `current-version`, `version-files`, `commit-message`, `branch-name`, `push`, `confirm`
+    unknown field `unknown-field`, expected one of `current-version`, `version-files`, `commit-message`, `branch-name`, `push`, `confirm`, `pre-commit-commands`
     "#);
 }
 

--- a/crates/seal_command/src/lib.rs
+++ b/crates/seal_command/src/lib.rs
@@ -59,4 +59,14 @@ impl CommandWrapper {
     pub fn git_push_branch(branch_name: &str) -> Self {
         Self::new(vec!["git", "push", "origin", branch_name])
     }
+
+    /// Create a custom command from a shell command string.
+    ///
+    /// The command string is split on whitespace. For complex commands with
+    /// quoted arguments, consider using `new` directly with a properly
+    /// constructed argument vector.
+    pub fn custom(command: &str) -> Self {
+        let parts: Vec<&str> = command.split_whitespace().collect();
+        Self::new(parts)
+    }
 }

--- a/crates/seal_project/src/config.rs
+++ b/crates/seal_project/src/config.rs
@@ -169,6 +169,18 @@ pub struct ReleaseConfig {
     confirm = true"#
     )]
     pub confirm: bool,
+
+    /// Commands to run before committing. These run after `git add -A` and before `git commit`.
+    /// A second `git add -A` is run after these commands to stage any changes they make.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[field(
+        default = "[]",
+        value_type = "list",
+        example = r#"
+        pre-commit-commands = ["cargo fmt", "npm run lint:fix"]
+    "#
+    )]
+    pub pre_commit_commands: Option<Vec<String>>,
 }
 
 fn default_push() -> bool {
@@ -513,7 +525,7 @@ unknown-field = "value"
         assert_debug_snapshot!(err, @r#"
         ConfigParseError(
             Error {
-                message: "unknown field `unknown-field`, expected one of `current-version`, `version-files`, `commit-message`, `branch-name`, `push`, `confirm`",
+                message: "unknown field `unknown-field`, expected one of `current-version`, `version-files`, `commit-message`, `branch-name`, `push`, `confirm`, `pre-commit-commands`",
                 input: Some(
                     "\n[release]\nunknown-field = \"value\"\n",
                 ),
@@ -751,6 +763,7 @@ branch-name = ""
                 branch_name: Some(BranchName::new("release/v{version}".to_string()).unwrap()),
                 push: true,
                 confirm: true,
+                pre_commit_commands: None,
             }),
             changelog: None,
         };
@@ -801,6 +814,7 @@ commit-message = "Release {version} with {version} tag"
                     branch_name: None,
                     push: false,
                     confirm: true,
+                    pre_commit_commands: None,
                 },
             ),
             changelog: None,
@@ -869,6 +883,7 @@ version-files = ["Cargo.toml", "package.json", "VERSION"]
                     branch_name: None,
                     push: false,
                     confirm: true,
+                    pre_commit_commands: None,
                 },
             ),
             changelog: None,
@@ -898,6 +913,7 @@ version-files = []
                     branch_name: None,
                     push: false,
                     confirm: true,
+                    pre_commit_commands: None,
                 },
             ),
             changelog: None,

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -224,6 +224,27 @@ The current version of the project.
 
 ---
 
+#### [`pre-commit-commands`](#release_pre-commit-commands)
+<span id="pre-commit-commands"></span>
+
+Commands to run before committing. These run after `git add -A` and before `git commit`.
+A second `git add -A` is run after these commands to stage any changes they make.
+
+**Default value**: `[]`
+
+**Type**: `list`
+
+**Example usage**:
+
+=== "seal.toml"
+
+    ```toml
+    [release]
+    pre-commit-commands = ["cargo fmt", "npm run lint:fix"]
+    ```
+
+---
+
 #### [`push`](#release_push)
 <span id="push"></span>
 

--- a/docs/usage/bumping_versions.md
+++ b/docs/usage/bumping_versions.md
@@ -100,7 +100,7 @@ pre-commit-commands = ["cargo fmt", "npm run lint:fix"]
 When you run `seal bump patch`, the command sequence will be:
 
 1. `git add -A` (stage version file changes)
-2. `cargo fmt` (format code)
-3. `npm run lint:fix` (fix lint issues)
-4. `git add -A` (stage any changes from pre-commit commands)
-5. `git commit -m "Release 0.0.2"`
+1. `cargo fmt` (format code)
+1. `npm run lint:fix` (fix lint issues)
+1. `git add -A` (stage any changes from pre-commit commands)
+1. `git commit -m "Release 0.0.2"`

--- a/docs/usage/bumping_versions.md
+++ b/docs/usage/bumping_versions.md
@@ -82,3 +82,25 @@ Proceed with these changes? (y/n):
 ```
 
 Once you proceed with `y`, the changes will be applied.
+
+## Pre-Commit Commands
+
+You can configure commands to run before committing using the `pre-commit-commands` option.
+These commands run after `git add -A` stages your version changes, allowing you to run
+formatters, linters, or other tools. A second `git add -A` runs after the pre-commit
+commands to stage any changes they make.
+
+```toml title="seal.toml"
+[release]
+current-version = "0.0.1"
+commit-message = "Release {version}"
+pre-commit-commands = ["cargo fmt", "npm run lint:fix"]
+```
+
+When you run `seal bump patch`, the command sequence will be:
+
+1. `git add -A` (stage version file changes)
+2. `cargo fmt` (format code)
+3. `npm run lint:fix` (fix lint issues)
+4. `git add -A` (stage any changes from pre-commit commands)
+5. `git commit -m "Release 0.0.2"`


### PR DESCRIPTION
## Summary

This PR adds support for "pre-commit-commands" commands that run prior to commit when bumping a version

## Test Plan

Add tests that the commands actually run prior to commit
