### PR TITLE
Pre commit failure

### DIFF
--- a/crates/seal/tests/it/validate/config.rs
+++ b/crates/seal/tests/it/validate/config.rs
@@ -348,7 +348,7 @@ unknown-field = "value"
       |
     3 | unknown-field = "value"
       | ^^^^^^^^^^^^^
-    unknown field `unknown-field`, expected one of `current-version`, `version-files`, `commit-message`, `branch-name`, `push`, `confirm`, `pre-commit-commands`
+    unknown field `unknown-field`, expected one of `current-version`, `version-files`, `commit-message`, `branch-name`, `push`, `confirm`, `pre-commit-commands`, `on-pre-commit-failure`
     "#);
 }
 

--- a/crates/seal_project/src/config.rs
+++ b/crates/seal_project/src/config.rs
@@ -205,7 +205,7 @@ pub struct ReleaseConfig {
     pub on_pre_commit_failure: PreCommitFailure,
 }
 
-#[allow(clippy::trivially_copy_pass_by_ref)]
+#[expect(clippy::trivially_copy_pass_by_ref)]
 fn is_default_pre_commit_failure(value: &PreCommitFailure) -> bool {
     *value == PreCommitFailure::Abort
 }

--- a/crates/seal_project/src/lib.rs
+++ b/crates/seal_project/src/lib.rs
@@ -6,8 +6,8 @@ mod project_name;
 mod workspace_member;
 
 pub use config::{
-    BranchName, ChangelogConfig, ChangelogHeading, CommitMessage, Config, ReleaseConfig,
-    VersionFile, VersionFileTextFormat,
+    BranchName, ChangelogConfig, ChangelogHeading, CommitMessage, Config, PreCommitFailure,
+    ReleaseConfig, VersionFile, VersionFileTextFormat,
 };
 pub use error::{ConfigValidationError, ProjectError};
 pub use git::find_git_root;

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -224,6 +224,30 @@ The current version of the project.
 
 ---
 
+#### [`on-pre-commit-failure`](#release_on-pre-commit-failure)
+<span id="on-pre-commit-failure"></span>
+
+Behavior when a pre-commit command fails.
+
+**Default value**: `abort`
+
+**Type**: `string`
+
+**Possible values**:
+- `abort` - Stop the release process if any pre-commit command fails
+- `continue` - Continue with the release even if pre-commit commands fail (logs warnings)
+
+**Example usage**:
+
+=== "seal.toml"
+
+    ```toml
+    [release]
+    on-pre-commit-failure = "continue"
+    ```
+
+---
+
 #### [`pre-commit-commands`](#release_pre-commit-commands)
 <span id="pre-commit-commands"></span>
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -233,17 +233,13 @@ Behavior when a pre-commit command fails.
 
 **Type**: `string`
 
-**Possible values**:
-- `abort` - Stop the release process if any pre-commit command fails
-- `continue` - Continue with the release even if pre-commit commands fail (logs warnings)
-
 **Example usage**:
 
 === "seal.toml"
 
     ```toml
     [release]
-    on-pre-commit-failure = "continue"
+    on-pre-commit-failure = "abort"  # or "continue"
     ```
 
 ---

--- a/docs/usage/bumping_versions.md
+++ b/docs/usage/bumping_versions.md
@@ -104,3 +104,18 @@ When you run `seal bump patch`, the command sequence will be:
 1. `npm run lint:fix` (fix lint issues)
 1. `git add -A` (stage any changes from pre-commit commands)
 1. `git commit -m "Release 0.0.2"`
+
+### Failure Handling
+
+By default, if any pre-commit command fails (exits with non-zero status), the release
+process will abort. You can change this behavior with `on-pre-commit-failure`:
+
+```toml title="seal.toml"
+[release]
+current-version = "0.0.1"
+commit-message = "Release {version}"
+pre-commit-commands = ["cargo fmt --check", "cargo clippy"]
+on-pre-commit-failure = "continue"  # or "abort" (default)
+```
+
+With `continue`, failing commands will log a warning but the release will proceed.


### PR DESCRIPTION
## Summary

This adds support for `on-pre-commit-failure` where a user can define what happens when a pre commit command fails.
