### PR TITLE
Move from karva-dev to MatthewMckee4

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yaml
@@ -6,7 +6,7 @@ body:
       value: |
         Thank you for taking the time to report an issue! We're glad to have you involved with seal.
 
-        **Before reporting, please make sure to search through [existing issues](https://github.com/karva-dev/seal/issues?q=is:issue+is:open+label:bug) (including [closed](https://github.com/karva-dev/seal/issues?q=is:issue%20state:closed%20label:bug)).**
+        **Before reporting, please make sure to search through [existing issues](https://github.com/MatthewMckee4/seal/issues?q=is:issue+is:open+label:bug) (including [closed](https://github.com/MatthewMckee4/seal/issues?q=is:issue%20state:closed%20label:bug)).**
 
   - type: textarea
     attributes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,5 +158,5 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
-          slug: karva-dev/seal
+          slug: MatthewMckee4/seal
           fail_ci_if_error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 ### Bumping
 
-- Update to bump command output ([#55](https://github.com/karva-dev/seal/pull/55))
-- Remove create PR ([#54](https://github.com/karva-dev/seal/pull/54))
+- Update to bump command output ([#55](https://github.com/MatthewMckee4/seal/pull/55))
+- Remove create PR ([#54](https://github.com/MatthewMckee4/seal/pull/54))
 
 ### Documentation
 
-- Update bump documentation ([#57](https://github.com/karva-dev/seal/pull/57))
+- Update bump documentation ([#57](https://github.com/MatthewMckee4/seal/pull/57))
 
 ### Contributors
 
@@ -19,19 +19,19 @@
 
 ### Bumping
 
-- Add more bump tests ([#49](https://github.com/karva-dev/seal/pull/49))
+- Add more bump tests ([#49](https://github.com/MatthewMckee4/seal/pull/49))
 
 ### CLI
 
-- Setup logging ([#48](https://github.com/karva-dev/seal/pull/48))
+- Setup logging ([#48](https://github.com/MatthewMckee4/seal/pull/48))
 
 ### Changelog
 
-- Support generating new changelog ([#45](https://github.com/karva-dev/seal/pull/45))
+- Support generating new changelog ([#45](https://github.com/MatthewMckee4/seal/pull/45))
 
 ### Documentation
 
-- Improve usage documentation ([#39](https://github.com/karva-dev/seal/pull/39))
+- Improve usage documentation ([#39](https://github.com/MatthewMckee4/seal/pull/39))
 
 ### Contributors
 
@@ -41,8 +41,8 @@
 
 ### Changelog
 
-- Support ignoring contributors in changelog ([#34](https://github.com/karva-dev/seal/pull/34))
-- Changelog support ([#32](https://github.com/karva-dev/seal/pull/32))
+- Support ignoring contributors in changelog ([#34](https://github.com/MatthewMckee4/seal/pull/34))
+- Changelog support ([#32](https://github.com/MatthewMckee4/seal/pull/32))
 
 ### Contributors
 
@@ -62,7 +62,7 @@
 
 ### Core Features
 
-- support `seal bump` command ([#7](https://github.com/karva-dev/seal/pull/7))
+- support `seal bump` command ([#7](https://github.com/MatthewMckee4/seal/pull/7))
 
 ### Contributors
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,11 +3,11 @@
 ## Finding ways to help
 
 We label issues that would be good for a first time contributor as
-[`good first issue`](https://github.com/karva-dev/seal/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
+[`good first issue`](https://github.com/MatthewMckee4/seal/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
 These usually do not require significant experience with code base.
 
 We label issues that we think are a good opportunity for subsequent contributions as
-[`help wanted`](https://github.com/karva-dev/seal/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22).
+[`help wanted`](https://github.com/MatthewMckee4/seal/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22).
 These require varying levels of experience.
 
 ## Setup
@@ -74,6 +74,6 @@ Then accept the changes.
 Then fix any issues there may be.
 
 After merging the pull request, run the
-[release workflow](https://github.com/karva-dev/seal/actions/workflows/release.yml) with the version
+[release workflow](https://github.com/MatthewMckee4/seal/actions/workflows/release.yml) with the version
 tag. **Do not include a leading `v`**. The release will automatically be created on GitHub after
 everything else publishes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 rust-version = "1.90"
-homepage = "https://github.com/karva-dev/seal"
-repository = "https://github.com/karva-dev/seal"
+homepage = "https://github.com/MatthewMckee4/seal"
+repository = "https://github.com/MatthewMckee4/seal"
 authors = ["Matthew Mckee <matthewmckee04@yahoo.co.uk>"]
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Seal
 
-[![codecov](https://codecov.io/gh/karva-dev/seal/graph/badge.svg?token=URQ3YZHYDK)](https://codecov.io/gh/karva-dev/seal)
+[![codecov](https://codecov.io/gh/MatthewMckee4/seal/graph/badge.svg?token=URQ3YZHYDK)](https://codecov.io/gh/MatthewMckee4/seal)
 
 An extremely fast release management tool, written in Rust.
 
@@ -25,19 +25,19 @@ Install uv with our standalone installers:
 
 ```shell
 # On macOS and Linux.
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/karva-dev/seal/releases/download/0.0.1-alpha.5/seal-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/MatthewMckee4/seal/releases/download/0.0.1-alpha.5/seal-installer.sh | sh
 ```
 
 ```shell
 # On Windows.
-powershell -ExecutionPolicy Bypass -c "irm https://github.com/karva-dev/seal/releases/download/0.0.1-alpha.5/seal-installer.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/MatthewMckee4/seal/releases/download/0.0.1-alpha.5/seal-installer.ps1 | iex"
 ```
 
 We do not (yet) have support for installation from other sources, like PyPI or cargo.
 
 ## Documentation
 
-seal's documentation is available at [karva-dev.github.io/seal](https://karva-dev.github.io/seal/)
+seal's documentation is available at [matthewmckee4.github.io/seal](https://matthewmckee4.github.io/seal/)
 
 ## Acknowledgements
 
@@ -49,5 +49,5 @@ Particularly, the projects [uv](https://github.com/astral-sh/uv) and [ruff](http
 
 Seal is licensed under the MIT License.
 
-We also include the [uv MIT license](https://github.com/karva-dev/seal/blob/main/licenses/astral.LICENSE-MIT), as we often
+We also include the [uv MIT license](https://github.com/MatthewMckee4/seal/blob/main/licenses/astral.LICENSE-MIT), as we often
 take inspiration or code snippets from the [uv](https://github.com/astral-sh/uv) repository.

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,10 +1,10 @@
 [project]
 site_name = "Seal"
-site_url = "https://karva-dev.github.io/seal"
+site_url = "https://matthewmckee4.github.io/seal"
 site_description = "A Release management tool, written in Rust"
 site_author = "Matthew McKee"
-repo_url = "https://github.com/karva-dev/seal"
-repo_name = "karva-dev/seal"
+repo_url = "https://github.com/MatthewMckee4/seal"
+repo_name = "MatthewMckee4/seal"
 
 docs_dir = "docs"
 site_dir = "site"


### PR DESCRIPTION
## Summary

The repository was transferred from `karva-dev/seal` to `MatthewMckee4/seal`; this updates the corresponding URLs across the codebase (Cargo metadata, docs site, README badges and installer URLs, CONTRIBUTING links, CHANGELOG PR links, the bug-report template, and the Codecov slug in CI).

## Test plan

ci