### PR TITLE
Create configurable pull requests for release bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +444,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,7 +618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -620,6 +648,12 @@ name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -807,6 +841,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,6 +870,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hkdf"
@@ -876,6 +935,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,9 +950,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1158,7 +1225,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1300,7 +1367,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1363,6 +1430,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1764,7 +1841,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1966,8 +2043,11 @@ dependencies = [
  "anyhow",
  "chrono",
  "octocrab",
+ "serde_json",
  "tempfile",
  "thiserror",
+ "tokio",
+ "wiremock",
 ]
 
 [[package]]
@@ -2349,7 +2429,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2455,6 +2535,7 @@ version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
@@ -2850,7 +2931,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3088,6 +3169,29 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ toml = { version = "0.9" }
 tracing = { version = "0.1.44" }
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 which = { version = "8.0.0" }
+wiremock = { version = "0.6" }
 
 [workspace.lints.rust]
 unsafe_code = "warn"

--- a/crates/seal/src/commands/bump.rs
+++ b/crates/seal/src/commands/bump.rs
@@ -245,6 +245,10 @@ pub async fn bump(args: &BumpArgs, printer: Printer) -> Result<ExitStatus> {
         writeln!(stdout)?;
     }
 
+    if pull_request.is_some() {
+        github_client.ensure_authenticated()?;
+    }
+
     writeln!(stdout, "Updating files...")?;
 
     file_changes.apply()?;

--- a/crates/seal/src/commands/bump.rs
+++ b/crates/seal/src/commands/bump.rs
@@ -6,8 +6,8 @@ use anyhow::{Context, Result};
 use seal_bump::{VersionBump, calculate_version_file_changes};
 use seal_command::CommandWrapper;
 use seal_fs::FileResolver;
-use seal_github::GitHubService;
-use seal_project::{PreCommitFailure, ProjectWorkspace};
+use seal_github::{GitHubPullRequestOptions, GitHubService};
+use seal_project::{PreCommitFailure, ProjectWorkspace, get_current_branch};
 
 use seal_cli::BumpArgs;
 
@@ -91,10 +91,11 @@ pub async fn bump(args: &BumpArgs, printer: Printer) -> Result<ExitStatus> {
         &new_version,
         &file_resolver,
     )?;
+    let mut changelog_body = String::new();
 
     if !args.no_changelog {
         if let Some(changelog_config) = config.changelog.as_ref() {
-            let changes = seal_changelog::prepare_changelog_changes(
+            let prepared_changelog = seal_changelog::prepare_changelog_changes(
                 workspace.root(),
                 &new_version_string,
                 changelog_config,
@@ -103,7 +104,8 @@ pub async fn bump(args: &BumpArgs, printer: Printer) -> Result<ExitStatus> {
             .await
             .context("Failed to prepare changelog")?;
 
-            file_changes.extend(changes);
+            changelog_body = prepared_changelog.section_body;
+            file_changes.extend(prepared_changelog.file_changes);
         } else {
             tracing::info!(
                 "Skipping changelog update because no `[changelog]` section was found in the configuration."
@@ -112,6 +114,38 @@ pub async fn bump(args: &BumpArgs, printer: Printer) -> Result<ExitStatus> {
     } else {
         tracing::info!("Skipping changelog update because `--no-changelog` was provided.");
     }
+
+    let pull_request = if let Some(pull_request_config) = &release_config.pull_request {
+        let default_title = commit_message
+            .as_deref()
+            .context("Pull request configuration requires commit-message")?;
+        let head = branch_name
+            .as_ref()
+            .context("Pull request configuration requires branch-name")?;
+        let base = if let Some(base) = &pull_request_config.base {
+            base.clone()
+        } else {
+            get_current_branch(workspace.root())?
+        };
+
+        Some(GitHubPullRequestOptions {
+            title: if let Some(title) = &pull_request_config.title {
+                title.replace("{version}", &new_version_string)
+            } else {
+                default_title.to_string()
+            },
+            body: if let Some(body) = &pull_request_config.body {
+                body.replace("{version}", &new_version_string)
+            } else {
+                changelog_body.clone()
+            },
+            head: head.clone(),
+            base,
+            draft: pull_request_config.draft,
+        })
+    } else {
+        None
+    };
 
     writeln!(stdout, "Preview of changes:")?;
     let width = seal_terminal::terminal_width();
@@ -180,6 +214,14 @@ pub async fn bump(args: &BumpArgs, printer: Printer) -> Result<ExitStatus> {
     }
 
     if args.dry_run {
+        if let Some(pull_request) = &pull_request {
+            writeln!(stdout, "Pull request:")?;
+            writeln!(stdout, "  Title: {}", pull_request.title)?;
+            writeln!(stdout, "  Base: {}", pull_request.base)?;
+            writeln!(stdout, "  Draft: {}", pull_request.draft)?;
+            writeln!(stdout)?;
+        }
+
         writeln!(stdout, "Dry run complete. No changes made.")?;
         return Ok(ExitStatus::Success);
     }
@@ -228,6 +270,14 @@ pub async fn bump(args: &BumpArgs, printer: Printer) -> Result<ExitStatus> {
         } else {
             tagged.command.execute(&mut stdout, workspace.root())?;
         }
+    }
+
+    if let Some(pull_request) = pull_request {
+        let pull_request = github_client
+            .create_or_update_pull_request(pull_request)
+            .await
+            .context("Failed to create or update GitHub pull request")?;
+        writeln!(stdout, "Pull request: {}", pull_request.url)?;
     }
 
     writeln!(stdout, "Successfully bumped to {new_version_string}")?;

--- a/crates/seal/tests/it/bump/mod.rs
+++ b/crates/seal/tests/it/bump/mod.rs
@@ -1217,6 +1217,88 @@ push = true
 }
 
 #[test]
+fn bump_pull_request_authentication_failure_makes_no_changes() {
+    let context = TestContext::new();
+
+    context.init_git();
+
+    context.seal_toml(
+        r#"
+[release]
+current-version = "1.2.3"
+version-files = ["README.md"]
+commit-message = "Release v{version}"
+branch-name = "release/v{version}"
+push = true
+confirm = false
+
+[release.pull-request]
+"#,
+    );
+
+    context
+        .root
+        .child("README.md")
+        .write_str("# My Package (1.2.3)")
+        .unwrap();
+
+    seal_snapshot!(context.filters(), context.command().env("SEAL_TEST_GITHUB_AUTHENTICATION_REQUIRED", "1").arg("bump").arg("patch"), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+    Bumping version from 1.2.3 to 1.2.4
+
+    Preview of changes:
+    ────────────────────────────────────────────────────────────────────────────────
+    Source: README.md
+    ────────────┬───────────────────────────────────────────────────────────────────
+        1       │-# My Package (1.2.3)
+              1 │+# My Package (1.2.4)
+    ────────────┴───────────────────────────────────────────────────────────────────
+    Source: seal.toml
+    ────────────┬───────────────────────────────────────────────────────────────────
+        1     1 │ [release]
+        2       │-current-version = "1.2.3"
+              2 │+current-version = "1.2.4"
+        3     3 │ version-files = ["README.md"]
+        4     4 │ commit-message = "Release v{version}"
+        5     5 │ branch-name = "release/v{version}"
+        6     6 │ push = true
+    ────────────┴───────────────────────────────────────────────────────────────────
+
+    Changes to be made:
+      - Update `README.md`
+      - Update `seal.toml`
+
+    Commands to be executed:
+      `git checkout -b release/v1.2.4`
+      `git add -A`
+      `git commit -m Release v1.2.4`
+      `git push origin release/v1.2.4`
+
+
+    ----- stderr -----
+    error: GitHub authentication is required; set GITHUB_TOKEN or GH_TOKEN
+    "#);
+
+    insta::assert_snapshot!(context.read_file("README.md"), @"# My Package (1.2.3)");
+    insta::assert_snapshot!(context.read_file("seal.toml"), @r#"
+    [release]
+    current-version = "1.2.3"
+    version-files = ["README.md"]
+    commit-message = "Release v{version}"
+    branch-name = "release/v{version}"
+    push = true
+    confirm = false
+
+    [release.pull-request]
+    "#);
+
+    insta::assert_snapshot!(context.git_current_branch(), @"HEAD");
+    insta::assert_snapshot!(context.git_last_commit_message(), @"");
+}
+
+#[test]
 fn bump_pull_request_dry_run_prints_defaults() {
     let context = TestContext::new();
 

--- a/crates/seal/tests/it/bump/mod.rs
+++ b/crates/seal/tests/it/bump/mod.rs
@@ -864,7 +864,7 @@ branch-name = "release/v{version}"
 }
 
 #[test]
-fn bump_patch_valid_commit_branch_push() {
+fn bump_pull_request_not_created_when_push_fails() {
     let context = TestContext::new();
 
     context.init_git();
@@ -877,6 +877,8 @@ version-files = ["README.md"]
 commit-message = "Release v{version}"
 branch-name = "release/v{version}"
 push = true
+
+[release.pull-request]
 "#,
     );
 
@@ -944,6 +946,8 @@ push = true
     commit-message = "Release v{version}"
     branch-name = "release/v{version}"
     push = true
+
+    [release.pull-request]
     "#);
 
     insta::assert_snapshot!(context.git_current_branch(), @"release/v1.2.4");
@@ -951,7 +955,7 @@ push = true
 }
 
 #[test]
-fn bump_patch_valid_commit_branch_push_pr() {
+fn bump_pull_request_dry_run_prints_defaults() {
     let context = TestContext::new();
 
     context.init_git();
@@ -964,6 +968,8 @@ version-files = ["README.md"]
 commit-message = "Release v{version}"
 branch-name = "release/v{version}"
 push = true
+
+[release.pull-request]
 "#,
     );
 
@@ -973,9 +979,9 @@ push = true
         .write_str("# My Package (1.2.3)")
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").write_stdin("y\n"), @r#"
-    success: false
-    exit_code: 2
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").arg("--dry-run"), @r#"
+    success: true
+    exit_code: 0
     ----- stdout -----
     Bumping version from 1.2.3 to 1.2.4
 
@@ -1001,47 +1007,90 @@ push = true
       - Update `README.md`
       - Update `seal.toml`
 
-    Commands to be executed:
-      `git checkout -b release/v1.2.4`
-      `git add -A`
-      `git commit -m Release v1.2.4`
-      `git push origin release/v1.2.4`
+    Pull request:
+      Title: Release v1.2.4
+      Base: main
+      Draft: false
 
-    Proceed with these changes? (y/n):
-    Updating files...
-    Executing command: `git checkout -b release/v1.2.4`
-    Executing command: `git add -A`
-    Executing command: `git commit -m Release v1.2.4`
-    Executing command: `git push origin release/v1.2.4`
+    Dry run complete. No changes made.
 
     ----- stderr -----
-    error: Command `git push origin release/v1.2.4` failed (exit code 128)
-    fatal: 'origin' does not appear to be a git repository
-    fatal: Could not read from remote repository.
-
-    Please make sure you have the correct access rights
-    and the repository exists.
     "#);
 
-    insta::assert_snapshot!(context.read_file("README.md"), @"# My Package (1.2.4)");
+    insta::assert_snapshot!(context.read_file("README.md"), @"# My Package (1.2.3)");
     insta::assert_snapshot!(context.read_file("seal.toml"), @r#"
     [release]
-    current-version = "1.2.4"
+    current-version = "1.2.3"
     version-files = ["README.md"]
     commit-message = "Release v{version}"
     branch-name = "release/v{version}"
     push = true
+
+    [release.pull-request]
     "#);
 
-    insta::assert_snapshot!(context.git_current_branch(), @"release/v1.2.4");
-    insta::assert_snapshot!(context.git_last_commit_message(), @"Release v1.2.4");
+    insta::assert_snapshot!(context.git_current_branch(), @"HEAD");
+    insta::assert_snapshot!(context.git_last_commit_message(), @"");
 }
 
 #[test]
-fn bump_patch_valid_commit_branch_push_pr_no_confirm() {
+fn bump_pull_request_dry_run_prints_custom_options() {
     let context = TestContext::new();
 
     context.init_git();
+
+    context.seal_toml(
+        r#"
+[release]
+current-version = "1.2.3"
+commit-message = "Release v{version}"
+branch-name = "release/v{version}"
+push = true
+[release.pull-request]
+title = "Ship {version}"
+base = "stable"
+draft = true
+"#,
+    );
+
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").arg("--dry-run"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Bumping version from 1.2.3 to 1.2.4
+
+    Preview of changes:
+    ────────────────────────────────────────────────────────────────────────────────
+    Source: seal.toml
+    ────────────┬───────────────────────────────────────────────────────────────────
+        1     1 │ [release]
+        2       │-current-version = "1.2.3"
+              2 │+current-version = "1.2.4"
+        3     3 │ commit-message = "Release v{version}"
+        4     4 │ branch-name = "release/v{version}"
+        5     5 │ push = true
+        6     6 │ [release.pull-request]
+    ────────────┴───────────────────────────────────────────────────────────────────
+
+    Changes to be made:
+      - Update `seal.toml`
+
+    Pull request:
+      Title: Ship 1.2.4
+      Base: stable
+      Draft: true
+
+    Dry run complete. No changes made.
+
+    ----- stderr -----
+    "#);
+}
+
+#[test]
+fn bump_pull_request_runs_after_successful_push() {
+    let context = TestContext::new();
+
+    context.init_git().init_git_remote();
 
     context.seal_toml(
         r#"
@@ -1052,6 +1101,8 @@ commit-message = "Release v{version}"
 branch-name = "release/v{version}"
 push = true
 confirm = false
+
+[release.pull-request]
 "#,
     );
 
@@ -1062,8 +1113,8 @@ confirm = false
         .unwrap();
 
     seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch"), @r#"
-    success: false
-    exit_code: 2
+    success: true
+    exit_code: 0
     ----- stdout -----
     Bumping version from 1.2.3 to 1.2.4
 
@@ -1100,14 +1151,10 @@ confirm = false
     Executing command: `git add -A`
     Executing command: `git commit -m Release v1.2.4`
     Executing command: `git push origin release/v1.2.4`
+    Pull request: https://github.com/owner/repo/pull/8
+    Successfully bumped to 1.2.4
 
     ----- stderr -----
-    error: Command `git push origin release/v1.2.4` failed (exit code 128)
-    fatal: 'origin' does not appear to be a git repository
-    fatal: Could not read from remote repository.
-
-    Please make sure you have the correct access rights
-    and the repository exists.
     "#);
 
     insta::assert_snapshot!(context.read_file("README.md"), @"# My Package (1.2.4)");
@@ -1119,6 +1166,8 @@ confirm = false
     branch-name = "release/v{version}"
     push = true
     confirm = false
+
+    [release.pull-request]
     "#);
 
     insta::assert_snapshot!(context.git_current_branch(), @"release/v1.2.4");

--- a/crates/seal/tests/it/bump/mod.rs
+++ b/crates/seal/tests/it/bump/mod.rs
@@ -864,6 +864,268 @@ branch-name = "release/v{version}"
 }
 
 #[test]
+fn bump_patch_valid_commit_branch_push() {
+    let context = TestContext::new();
+
+    context.init_git();
+
+    context.seal_toml(
+        r#"
+[release]
+current-version = "1.2.3"
+version-files = ["README.md"]
+commit-message = "Release v{version}"
+branch-name = "release/v{version}"
+push = true
+"#,
+    );
+
+    context
+        .root
+        .child("README.md")
+        .write_str("# My Package (1.2.3)")
+        .unwrap();
+
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").write_stdin("y\n"), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+    Bumping version from 1.2.3 to 1.2.4
+
+    Preview of changes:
+    ────────────────────────────────────────────────────────────────────────────────
+    Source: README.md
+    ────────────┬───────────────────────────────────────────────────────────────────
+        1       │-# My Package (1.2.3)
+              1 │+# My Package (1.2.4)
+    ────────────┴───────────────────────────────────────────────────────────────────
+    Source: seal.toml
+    ────────────┬───────────────────────────────────────────────────────────────────
+        1     1 │ [release]
+        2       │-current-version = "1.2.3"
+              2 │+current-version = "1.2.4"
+        3     3 │ version-files = ["README.md"]
+        4     4 │ commit-message = "Release v{version}"
+        5     5 │ branch-name = "release/v{version}"
+        6     6 │ push = true
+    ────────────┴───────────────────────────────────────────────────────────────────
+
+    Changes to be made:
+      - Update `README.md`
+      - Update `seal.toml`
+
+    Commands to be executed:
+      `git checkout -b release/v1.2.4`
+      `git add -A`
+      `git commit -m Release v1.2.4`
+      `git push origin release/v1.2.4`
+
+    Proceed with these changes? (y/n):
+    Updating files...
+    Executing command: `git checkout -b release/v1.2.4`
+    Executing command: `git add -A`
+    Executing command: `git commit -m Release v1.2.4`
+    Executing command: `git push origin release/v1.2.4`
+
+    ----- stderr -----
+    error: Command `git push origin release/v1.2.4` failed (exit code 128)
+    fatal: 'origin' does not appear to be a git repository
+    fatal: Could not read from remote repository.
+
+    Please make sure you have the correct access rights
+    and the repository exists.
+    "#);
+
+    insta::assert_snapshot!(context.read_file("README.md"), @"# My Package (1.2.4)");
+    insta::assert_snapshot!(context.read_file("seal.toml"), @r#"
+    [release]
+    current-version = "1.2.4"
+    version-files = ["README.md"]
+    commit-message = "Release v{version}"
+    branch-name = "release/v{version}"
+    push = true
+    "#);
+
+    insta::assert_snapshot!(context.git_current_branch(), @"release/v1.2.4");
+    insta::assert_snapshot!(context.git_last_commit_message(), @"Release v1.2.4");
+}
+
+#[test]
+fn bump_patch_valid_commit_branch_push_pr() {
+    let context = TestContext::new();
+
+    context.init_git();
+
+    context.seal_toml(
+        r#"
+[release]
+current-version = "1.2.3"
+version-files = ["README.md"]
+commit-message = "Release v{version}"
+branch-name = "release/v{version}"
+push = true
+"#,
+    );
+
+    context
+        .root
+        .child("README.md")
+        .write_str("# My Package (1.2.3)")
+        .unwrap();
+
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").write_stdin("y\n"), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+    Bumping version from 1.2.3 to 1.2.4
+
+    Preview of changes:
+    ────────────────────────────────────────────────────────────────────────────────
+    Source: README.md
+    ────────────┬───────────────────────────────────────────────────────────────────
+        1       │-# My Package (1.2.3)
+              1 │+# My Package (1.2.4)
+    ────────────┴───────────────────────────────────────────────────────────────────
+    Source: seal.toml
+    ────────────┬───────────────────────────────────────────────────────────────────
+        1     1 │ [release]
+        2       │-current-version = "1.2.3"
+              2 │+current-version = "1.2.4"
+        3     3 │ version-files = ["README.md"]
+        4     4 │ commit-message = "Release v{version}"
+        5     5 │ branch-name = "release/v{version}"
+        6     6 │ push = true
+    ────────────┴───────────────────────────────────────────────────────────────────
+
+    Changes to be made:
+      - Update `README.md`
+      - Update `seal.toml`
+
+    Commands to be executed:
+      `git checkout -b release/v1.2.4`
+      `git add -A`
+      `git commit -m Release v1.2.4`
+      `git push origin release/v1.2.4`
+
+    Proceed with these changes? (y/n):
+    Updating files...
+    Executing command: `git checkout -b release/v1.2.4`
+    Executing command: `git add -A`
+    Executing command: `git commit -m Release v1.2.4`
+    Executing command: `git push origin release/v1.2.4`
+
+    ----- stderr -----
+    error: Command `git push origin release/v1.2.4` failed (exit code 128)
+    fatal: 'origin' does not appear to be a git repository
+    fatal: Could not read from remote repository.
+
+    Please make sure you have the correct access rights
+    and the repository exists.
+    "#);
+
+    insta::assert_snapshot!(context.read_file("README.md"), @"# My Package (1.2.4)");
+    insta::assert_snapshot!(context.read_file("seal.toml"), @r#"
+    [release]
+    current-version = "1.2.4"
+    version-files = ["README.md"]
+    commit-message = "Release v{version}"
+    branch-name = "release/v{version}"
+    push = true
+    "#);
+
+    insta::assert_snapshot!(context.git_current_branch(), @"release/v1.2.4");
+    insta::assert_snapshot!(context.git_last_commit_message(), @"Release v1.2.4");
+}
+
+#[test]
+fn bump_patch_valid_commit_branch_push_pr_no_confirm() {
+    let context = TestContext::new();
+
+    context.init_git();
+
+    context.seal_toml(
+        r#"
+[release]
+current-version = "1.2.3"
+version-files = ["README.md"]
+commit-message = "Release v{version}"
+branch-name = "release/v{version}"
+push = true
+confirm = false
+"#,
+    );
+
+    context
+        .root
+        .child("README.md")
+        .write_str("# My Package (1.2.3)")
+        .unwrap();
+
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch"), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+    Bumping version from 1.2.3 to 1.2.4
+
+    Preview of changes:
+    ────────────────────────────────────────────────────────────────────────────────
+    Source: README.md
+    ────────────┬───────────────────────────────────────────────────────────────────
+        1       │-# My Package (1.2.3)
+              1 │+# My Package (1.2.4)
+    ────────────┴───────────────────────────────────────────────────────────────────
+    Source: seal.toml
+    ────────────┬───────────────────────────────────────────────────────────────────
+        1     1 │ [release]
+        2       │-current-version = "1.2.3"
+              2 │+current-version = "1.2.4"
+        3     3 │ version-files = ["README.md"]
+        4     4 │ commit-message = "Release v{version}"
+        5     5 │ branch-name = "release/v{version}"
+        6     6 │ push = true
+    ────────────┴───────────────────────────────────────────────────────────────────
+
+    Changes to be made:
+      - Update `README.md`
+      - Update `seal.toml`
+
+    Commands to be executed:
+      `git checkout -b release/v1.2.4`
+      `git add -A`
+      `git commit -m Release v1.2.4`
+      `git push origin release/v1.2.4`
+
+    Updating files...
+    Executing command: `git checkout -b release/v1.2.4`
+    Executing command: `git add -A`
+    Executing command: `git commit -m Release v1.2.4`
+    Executing command: `git push origin release/v1.2.4`
+
+    ----- stderr -----
+    error: Command `git push origin release/v1.2.4` failed (exit code 128)
+    fatal: 'origin' does not appear to be a git repository
+    fatal: Could not read from remote repository.
+
+    Please make sure you have the correct access rights
+    and the repository exists.
+    "#);
+
+    insta::assert_snapshot!(context.read_file("README.md"), @"# My Package (1.2.4)");
+    insta::assert_snapshot!(context.read_file("seal.toml"), @r#"
+    [release]
+    current-version = "1.2.4"
+    version-files = ["README.md"]
+    commit-message = "Release v{version}"
+    branch-name = "release/v{version}"
+    push = true
+    confirm = false
+    "#);
+
+    insta::assert_snapshot!(context.git_current_branch(), @"release/v1.2.4");
+    insta::assert_snapshot!(context.git_last_commit_message(), @"Release v1.2.4");
+}
+
+#[test]
 fn bump_pull_request_not_created_when_push_fails() {
     let context = TestContext::new();
 

--- a/crates/seal/tests/it/common/mod.rs
+++ b/crates/seal/tests/it/common/mod.rs
@@ -178,6 +178,36 @@ current-version = "{version}"
         self
     }
 
+    /// Add a local bare repository as `origin`.
+    pub fn init_git_remote(&self) -> &Self {
+        let remote = self.root.join(".git/remote.git");
+
+        let output = std::process::Command::new("git")
+            .args(["init", "--bare"])
+            .arg(&remote)
+            .output()
+            .expect("Failed to initialize git remote");
+        assert!(
+            output.status.success(),
+            "Failed to initialize git remote: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let output = std::process::Command::new("git")
+            .args(["remote", "add", "origin"])
+            .arg(&remote)
+            .current_dir(self.root.path())
+            .output()
+            .expect("Failed to add git remote");
+        assert!(
+            output.status.success(),
+            "Failed to add git remote: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        self
+    }
+
     /// Get the current git branch name.
     pub fn git_current_branch(&self) -> String {
         let output = std::process::Command::new("git")

--- a/crates/seal/tests/it/validate/config.rs
+++ b/crates/seal/tests/it/validate/config.rs
@@ -28,6 +28,35 @@ confirm = false
 }
 
 #[test]
+fn validate_config_with_pull_request() {
+    let context = TestContext::new();
+    context.seal_toml(
+        r#"
+[release]
+current-version = "1.0.0"
+commit-message = "Release v{version}"
+branch-name = "release/v{version}"
+push = true
+
+[release.pull-request]
+title = "Release v{version}"
+body = "Prepare the release."
+base = "main"
+draft = true
+"#,
+    );
+
+    seal_snapshot!(context.filters(), context.command().arg("validate").arg("config"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Config file `seal.toml` is valid
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
 fn validate_config_with_explicit_path() {
     let context = TestContext::new();
     let custom_config = context.root.child("custom.toml");
@@ -196,6 +225,83 @@ branch-name = ""
 }
 
 #[test]
+fn validate_config_pull_request_requires_release_workflow() {
+    let context = TestContext::new();
+    context.seal_toml(
+        r#"
+[release]
+current-version = "1.0.0"
+
+[release.pull-request]
+"#,
+    );
+
+    seal_snapshot!(context.command().arg("validate").arg("config"), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Invalid configuration file: release.pull-request requires release.commit-message, release.branch-name, and release.push = true
+      Caused by: release.pull-request requires release.commit-message, release.branch-name, and release.push = true
+    ");
+}
+
+#[test]
+fn validate_config_empty_pull_request_title() {
+    let context = TestContext::new();
+    context.seal_toml(
+        r#"
+[release]
+current-version = "1.0.0"
+commit-message = "Release v{version}"
+branch-name = "release/v{version}"
+push = true
+
+[release.pull-request]
+title = "   "
+"#,
+    );
+
+    seal_snapshot!(context.command().arg("validate").arg("config"), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Invalid configuration file: release.pull-request.title cannot be empty
+      Caused by: release.pull-request.title cannot be empty
+    ");
+}
+
+#[test]
+fn validate_config_empty_pull_request_base() {
+    let context = TestContext::new();
+    context.seal_toml(
+        r#"
+[release]
+current-version = "1.0.0"
+commit-message = "Release v{version}"
+branch-name = "release/v{version}"
+push = true
+
+[release.pull-request]
+base = "   "
+"#,
+    );
+
+    seal_snapshot!(context.command().arg("validate").arg("config"), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: Invalid configuration file: release.pull-request.base cannot be empty
+      Caused by: release.pull-request.base cannot be empty
+    ");
+}
+
+#[test]
 fn validate_config_empty_tag_format() {
     let context = TestContext::new();
     context.seal_toml(
@@ -348,7 +454,7 @@ unknown-field = "value"
       |
     3 | unknown-field = "value"
       | ^^^^^^^^^^^^^
-    unknown field `unknown-field`, expected one of `current-version`, `version-files`, `commit-message`, `branch-name`, `push`, `confirm`, `pre-commit-commands`, `on-pre-commit-failure`
+    unknown field `unknown-field`, expected one of `current-version`, `version-files`, `commit-message`, `branch-name`, `push`, `confirm`, `pre-commit-commands`, `on-pre-commit-failure`, `pull-request`
     "#);
 }
 

--- a/crates/seal_changelog/src/lib.rs
+++ b/crates/seal_changelog/src/lib.rs
@@ -178,12 +178,28 @@ pub fn prepare_changelog_file_change(
     ))
 }
 
+pub struct PreparedChangelog {
+    pub file_changes: FileChanges,
+    pub section_body: String,
+}
+
+impl PreparedChangelog {
+    fn new(file_changes: FileChanges, generated_section: &str) -> Result<Self> {
+        let section_body = parse_latest_changelog_section(generated_section)?.body;
+
+        Ok(Self {
+            file_changes,
+            section_body,
+        })
+    }
+}
+
 pub async fn prepare_changelog_changes(
     root: &Path,
     version: &str,
     config: &ChangelogConfig,
     github_client: &Arc<dyn GitHubService>,
-) -> Result<FileChanges> {
+) -> Result<PreparedChangelog> {
     let generator = ChangelogGenerator::new(github_client);
     let changelog_content = generator.generate_changelog(version, config).await?;
 
@@ -194,7 +210,7 @@ pub async fn prepare_changelog_changes(
     };
     let change = prepare_changelog_file_change(&changelog_path, &changelog_content)?;
 
-    Ok(FileChanges::new(vec![change]))
+    PreparedChangelog::new(FileChanges::new(vec![change]), &changelog_content)
 }
 
 pub async fn generate_full_changelog(
@@ -652,6 +668,20 @@ mod tests {
         - Old feature
 
         "###);
+    }
+
+    #[test]
+    fn test_prepared_changelog_has_section_body_without_heading() {
+        let prepared = PreparedChangelog::new(
+            FileChanges::new(Vec::new()),
+            "## 1.2.3\n\n### Features\n\n- Added release pull requests\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            prepared.section_body,
+            "### Features\n\n- Added release pull requests"
+        );
     }
 
     #[test]

--- a/crates/seal_github/Cargo.toml
+++ b/crates/seal_github/Cargo.toml
@@ -12,10 +12,13 @@ license.workspace = true
 anyhow = { workspace = true }
 chrono = { workspace = true }
 octocrab = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+tokio = { workspace = true }
+wiremock = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/seal_github/src/github.rs
+++ b/crates/seal_github/src/github.rs
@@ -9,6 +9,8 @@ pub use client::GitHubClient;
 pub use mock::MockGithubClient;
 
 pub trait GitHubService: Send + Sync {
+    fn ensure_authenticated(&self) -> Result<()>;
+
     fn get_latest_release(
         &self,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<GitHubRelease>> + Send + '_>>;
@@ -51,6 +53,15 @@ pub enum GitHubError {
     AuthenticationRequired,
     #[error("GitHub did not return a browser URL for pull request #{number}")]
     MissingPullRequestUrl { number: u64 },
+    #[error(
+        "GitHub did not return a node ID for pull request #{number}; cannot update its draft state"
+    )]
+    MissingPullRequestNodeId { number: u64 },
+    #[error("Failed to {action}: GitHub returned GraphQL errors: {errors}")]
+    GraphQlErrors {
+        action: &'static str,
+        errors: String,
+    },
 }
 
 #[derive(Debug, Clone)]

--- a/crates/seal_github/src/github.rs
+++ b/crates/seal_github/src/github.rs
@@ -34,12 +34,23 @@ pub trait GitHubService: Send + Sync {
     ) -> std::pin::Pin<
         Box<dyn std::future::Future<Output = Result<Vec<GitHubPullRequest>>> + Send + '_>,
     >;
+
+    fn create_or_update_pull_request(
+        &self,
+        options: GitHubPullRequestOptions,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<GitHubPullRequestReference>> + Send + '_>,
+    >;
 }
 
 #[derive(Debug, Error)]
 pub enum GitHubError {
     #[error("No releases found for {owner}/{repo}")]
     NoReleasesFound { owner: String, repo: String },
+    #[error("GitHub authentication is required; set GITHUB_TOKEN or GH_TOKEN")]
+    AuthenticationRequired,
+    #[error("GitHub did not return a browser URL for pull request #{number}")]
+    MissingPullRequestUrl { number: u64 },
 }
 
 #[derive(Debug, Clone)]
@@ -56,6 +67,20 @@ pub struct GitHubPullRequest {
     pub labels: Vec<String>,
     pub author: Option<String>,
     pub merged_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GitHubPullRequestOptions {
+    pub title: String,
+    pub body: String,
+    pub head: String,
+    pub base: String,
+    pub draft: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitHubPullRequestReference {
+    pub url: String,
 }
 
 pub fn filter_prs_by_date_range(

--- a/crates/seal_github/src/github/client.rs
+++ b/crates/seal_github/src/github/client.rs
@@ -1,21 +1,28 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use octocrab::{Octocrab, models::pulls::PullRequest};
 
-use crate::github::{GitHubError, GitHubPullRequest, GitHubRelease, GitHubService};
+use crate::github::{
+    GitHubError, GitHubPullRequest, GitHubPullRequestOptions, GitHubPullRequestReference,
+    GitHubRelease, GitHubService,
+};
 
 #[derive(Debug)]
 pub struct GitHubClient {
     octocrab: Octocrab,
     owner: String,
     repo: String,
+    authenticated: bool,
 }
 
 impl GitHubClient {
     pub fn new(owner: String, repo: String) -> Result<Self> {
-        let github_token = std::env::var("GITHUB_TOKEN")
-            .or_else(|_| std::env::var("GH_TOKEN"))
-            .ok();
+        let github_token = ["GITHUB_TOKEN", "GH_TOKEN"].into_iter().find_map(|name| {
+            std::env::var(name)
+                .ok()
+                .filter(|token| !token.trim().is_empty())
+        });
+        let authenticated = github_token.is_some();
 
         let mut octocrab = Octocrab::builder();
 
@@ -29,6 +36,7 @@ impl GitHubClient {
             octocrab,
             owner,
             repo,
+            authenticated,
         })
     }
 }
@@ -200,6 +208,64 @@ impl GitHubService for GitHubClient {
 
             all_prs.truncate(max_prs);
             Ok(all_prs)
+        })
+    }
+
+    fn create_or_update_pull_request(
+        &self,
+        options: GitHubPullRequestOptions,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<GitHubPullRequestReference>> + Send + '_>,
+    > {
+        Box::pin(async move {
+            if !self.authenticated {
+                return Err(GitHubError::AuthenticationRequired.into());
+            }
+
+            let pull_requests = self.octocrab.pulls(&self.owner, &self.repo);
+            let existing = pull_requests
+                .list()
+                .state(octocrab::params::State::Open)
+                .head(format!("{}:{}", self.owner, options.head))
+                .base(options.base.as_str())
+                .per_page(1)
+                .send()
+                .await
+                .context("Failed to find an existing GitHub pull request")?
+                .items
+                .into_iter()
+                .next();
+
+            let pull_request = if let Some(existing) = existing {
+                pull_requests
+                    .update(existing.number)
+                    .title(options.title.as_str())
+                    .body(options.body.as_str())
+                    .send()
+                    .await
+                    .context("Failed to update GitHub pull request")?
+            } else {
+                pull_requests
+                    .create(
+                        options.title.as_str(),
+                        options.head.as_str(),
+                        options.base.as_str(),
+                    )
+                    .body(options.body.as_str())
+                    .draft(options.draft)
+                    .send()
+                    .await
+                    .context("Failed to create GitHub pull request")?
+            };
+
+            let number = pull_request.number;
+            let url = pull_request
+                .html_url
+                .ok_or(GitHubError::MissingPullRequestUrl { number })?;
+
+            Ok(GitHubPullRequestReference {
+                url: url.to_string(),
+            })
         })
     }
 }

--- a/crates/seal_github/src/github/client.rs
+++ b/crates/seal_github/src/github/client.rs
@@ -7,6 +7,17 @@ use crate::github::{
     GitHubRelease, GitHubService,
 };
 
+const CONVERT_PULL_REQUEST_TO_DRAFT: &str = "mutation ConvertPullRequestToDraft($pullRequestId: ID!) {\
+        convertPullRequestToDraft(input: { pullRequestId: $pullRequestId }) {\
+            pullRequest { isDraft }\
+        }\
+    }";
+const MARK_PULL_REQUEST_READY_FOR_REVIEW: &str = "mutation MarkPullRequestReadyForReview($pullRequestId: ID!) {\
+        markPullRequestReadyForReview(input: { pullRequestId: $pullRequestId }) {\
+            pullRequest { isDraft }\
+        }\
+    }";
+
 #[derive(Debug)]
 pub struct GitHubClient {
     octocrab: Octocrab,
@@ -39,9 +50,52 @@ impl GitHubClient {
             authenticated,
         })
     }
+
+    async fn update_pull_request_draft_state(&self, node_id: &str, draft: bool) -> Result<()> {
+        let (action, query) = if draft {
+            (
+                "convert GitHub pull request to draft",
+                CONVERT_PULL_REQUEST_TO_DRAFT,
+            )
+        } else {
+            (
+                "mark GitHub pull request ready for review",
+                MARK_PULL_REQUEST_READY_FOR_REVIEW,
+            )
+        };
+
+        let response: serde_json::Value = self
+            .octocrab
+            .graphql(&serde_json::json!({
+                "query": query,
+                "variables": { "pullRequestId": node_id },
+            }))
+            .await
+            .with_context(|| format!("Failed to {action}"))?;
+
+        if let Some(errors) = response.get("errors").and_then(serde_json::Value::as_array)
+            && !errors.is_empty()
+        {
+            return Err(GitHubError::GraphQlErrors {
+                action,
+                errors: serde_json::Value::Array(errors.clone()).to_string(),
+            }
+            .into());
+        }
+
+        Ok(())
+    }
 }
 
 impl GitHubService for GitHubClient {
+    fn ensure_authenticated(&self) -> Result<()> {
+        if !self.authenticated {
+            return Err(GitHubError::AuthenticationRequired.into());
+        }
+
+        Ok(())
+    }
+
     fn get_latest_release(
         &self,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<GitHubRelease>> + Send + '_>>
@@ -218,9 +272,7 @@ impl GitHubService for GitHubClient {
         Box<dyn std::future::Future<Output = Result<GitHubPullRequestReference>> + Send + '_>,
     > {
         Box::pin(async move {
-            if !self.authenticated {
-                return Err(GitHubError::AuthenticationRequired.into());
-            }
+            self.ensure_authenticated()?;
 
             let pull_requests = self.octocrab.pulls(&self.owner, &self.repo);
             let existing = pull_requests
@@ -237,13 +289,26 @@ impl GitHubService for GitHubClient {
                 .next();
 
             let pull_request = if let Some(existing) = existing {
-                pull_requests
+                let number = existing.number;
+                let node_id = existing.node_id;
+                let draft_state_changed = existing.draft != Some(options.draft);
+
+                let pull_request = pull_requests
                     .update(existing.number)
                     .title(options.title.as_str())
                     .body(options.body.as_str())
                     .send()
                     .await
-                    .context("Failed to update GitHub pull request")?
+                    .context("Failed to update GitHub pull request")?;
+
+                if draft_state_changed {
+                    let node_id =
+                        node_id.ok_or(GitHubError::MissingPullRequestNodeId { number })?;
+                    self.update_pull_request_draft_state(&node_id, options.draft)
+                        .await?;
+                }
+
+                pull_request
             } else {
                 pull_requests
                     .create(
@@ -284,4 +349,375 @@ fn gh_pr_to_github_pull_request(pr: PullRequest) -> Option<GitHubPullRequest> {
             merged_at,
         })
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::{Context as _, Result};
+    use octocrab::Octocrab;
+    use serde_json::{Value, json};
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_json, method, path, query_param},
+    };
+
+    use super::{CONVERT_PULL_REQUEST_TO_DRAFT, GitHubClient, MARK_PULL_REQUEST_READY_FOR_REVIEW};
+    use crate::github::{GitHubError, GitHubPullRequestOptions, GitHubService};
+
+    const OWNER: &str = "owner";
+    const REPO: &str = "repo";
+    const TITLE: &str = "Release v1.2.4";
+    const BODY: &str = "Release notes";
+    const HEAD: &str = "release/v1.2.4";
+    const BASE: &str = "main";
+    const PULL_NUMBER: u64 = 8;
+    const NODE_ID: &str = "PR_8";
+
+    fn test_client(server: &MockServer, authenticated: bool) -> Result<GitHubClient> {
+        let octocrab = Octocrab::builder().base_uri(server.uri())?.build()?;
+
+        Ok(GitHubClient {
+            octocrab,
+            owner: OWNER.to_string(),
+            repo: REPO.to_string(),
+            authenticated,
+        })
+    }
+
+    fn options(draft: bool) -> GitHubPullRequestOptions {
+        GitHubPullRequestOptions {
+            title: TITLE.to_string(),
+            body: BODY.to_string(),
+            head: HEAD.to_string(),
+            base: BASE.to_string(),
+            draft,
+        }
+    }
+
+    fn pull_request(number: u64, draft: bool, node_id: Option<&str>) -> Value {
+        json!({
+            "url": format!("https://api.github.com/repos/{OWNER}/{REPO}/pulls/{number}"),
+            "id": number,
+            "node_id": node_id,
+            "html_url": format!("https://github.com/{OWNER}/{REPO}/pull/{number}"),
+            "number": number,
+            "locked": false,
+            "maintainer_can_modify": true,
+            "head": {
+                "ref": HEAD,
+                "sha": "head-sha",
+            },
+            "base": {
+                "ref": BASE,
+                "sha": "base-sha",
+            },
+            "draft": draft,
+        })
+    }
+
+    async fn mount_lookup(server: &MockServer, response: Vec<Value>) {
+        Mock::given(method("GET"))
+            .and(path(format!("/repos/{OWNER}/{REPO}/pulls")))
+            .and(query_param("state", "open"))
+            .and(query_param("head", format!("{OWNER}:{HEAD}")))
+            .and(query_param("base", BASE))
+            .and(query_param("per_page", "1"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(response))
+            .expect(1)
+            .mount(server)
+            .await;
+    }
+
+    async fn mount_update(server: &MockServer, draft: bool) {
+        Mock::given(method("PATCH"))
+            .and(path(format!("/repos/{OWNER}/{REPO}/pulls/{PULL_NUMBER}")))
+            .and(body_json(json!({
+                "pull_number": PULL_NUMBER,
+                "title": TITLE,
+                "body": BODY,
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(pull_request(
+                PULL_NUMBER,
+                draft,
+                Some(NODE_ID),
+            )))
+            .expect(1)
+            .mount(server)
+            .await;
+    }
+
+    async fn mount_graphql(server: &MockServer, query: &str, response: Value) {
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .and(body_json(json!({
+                "query": query,
+                "variables": { "pullRequestId": NODE_ID },
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(response))
+            .expect(1)
+            .mount(server)
+            .await;
+    }
+
+    async fn assert_received_paths(server: &MockServer, expected: &[&str]) -> Result<()> {
+        let actual = server
+            .received_requests()
+            .await
+            .context("Wiremock request recording is disabled")?
+            .iter()
+            .map(|request| request.url.path().to_string())
+            .collect::<Vec<_>>();
+        let expected = expected.iter().map(ToString::to_string).collect::<Vec<_>>();
+        assert_eq!(actual, expected);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn unauthenticated_preflight_and_write_fail_without_requests() -> Result<()> {
+        let server = MockServer::start().await;
+        let client = test_client(&server, false)?;
+
+        let preflight_error = client
+            .ensure_authenticated()
+            .expect_err("authentication preflight should fail");
+        assert!(matches!(
+            preflight_error.downcast_ref::<GitHubError>(),
+            Some(GitHubError::AuthenticationRequired)
+        ));
+
+        let write_error = client
+            .create_or_update_pull_request(options(false))
+            .await
+            .expect_err("unauthenticated write should fail");
+        assert!(matches!(
+            write_error.downcast_ref::<GitHubError>(),
+            Some(GitHubError::AuthenticationRequired)
+        ));
+        assert_received_paths(&server, &[]).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn creates_pull_request_when_none_exists() -> Result<()> {
+        let server = MockServer::start().await;
+        mount_lookup(&server, Vec::new()).await;
+        Mock::given(method("POST"))
+            .and(path(format!("/repos/{OWNER}/{REPO}/pulls")))
+            .and(body_json(json!({
+                "title": TITLE,
+                "head": HEAD,
+                "base": BASE,
+                "body": BODY,
+                "draft": true,
+            })))
+            .respond_with(ResponseTemplate::new(201).set_body_json(pull_request(
+                9,
+                true,
+                Some("PR_9"),
+            )))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let pull_request = test_client(&server, true)?
+            .create_or_update_pull_request(options(true))
+            .await?;
+
+        assert_eq!(pull_request.url, "https://github.com/owner/repo/pull/9");
+        assert_received_paths(
+            &server,
+            &["/repos/owner/repo/pulls", "/repos/owner/repo/pulls"],
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_failure_has_stage_specific_context() -> Result<()> {
+        let server = MockServer::start().await;
+        mount_lookup(&server, Vec::new()).await;
+        Mock::given(method("POST"))
+            .and(path(format!("/repos/{OWNER}/{REPO}/pulls")))
+            .and(body_json(json!({
+                "title": TITLE,
+                "head": HEAD,
+                "base": BASE,
+                "body": BODY,
+                "draft": false,
+            })))
+            .respond_with(
+                ResponseTemplate::new(422).set_body_json(json!({ "message": "Invalid request" })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let error = test_client(&server, true)?
+            .create_or_update_pull_request(options(false))
+            .await
+            .expect_err("failed create request should return an error");
+        let message = format!("{error:#}");
+
+        assert!(message.contains("Failed to create GitHub pull request"));
+        assert!(message.contains("Invalid request"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn converts_existing_ready_pull_request_to_draft() -> Result<()> {
+        let server = MockServer::start().await;
+        mount_lookup(
+            &server,
+            vec![pull_request(PULL_NUMBER, false, Some(NODE_ID))],
+        )
+        .await;
+        mount_update(&server, false).await;
+        mount_graphql(
+            &server,
+            CONVERT_PULL_REQUEST_TO_DRAFT,
+            json!({
+                "data": {
+                    "convertPullRequestToDraft": {
+                        "pullRequest": { "isDraft": true }
+                    }
+                }
+            }),
+        )
+        .await;
+
+        test_client(&server, true)?
+            .create_or_update_pull_request(options(true))
+            .await?;
+
+        assert_received_paths(
+            &server,
+            &[
+                "/repos/owner/repo/pulls",
+                "/repos/owner/repo/pulls/8",
+                "/graphql",
+            ],
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn marks_existing_draft_pull_request_ready_for_review() -> Result<()> {
+        let server = MockServer::start().await;
+        mount_lookup(
+            &server,
+            vec![pull_request(PULL_NUMBER, true, Some(NODE_ID))],
+        )
+        .await;
+        mount_update(&server, true).await;
+        mount_graphql(
+            &server,
+            MARK_PULL_REQUEST_READY_FOR_REVIEW,
+            json!({
+                "data": {
+                    "markPullRequestReadyForReview": {
+                        "pullRequest": { "isDraft": false }
+                    }
+                }
+            }),
+        )
+        .await;
+
+        test_client(&server, true)?
+            .create_or_update_pull_request(options(false))
+            .await?;
+
+        assert_received_paths(
+            &server,
+            &[
+                "/repos/owner/repo/pulls",
+                "/repos/owner/repo/pulls/8",
+                "/graphql",
+            ],
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn matching_draft_state_only_updates_title_and_body() -> Result<()> {
+        let server = MockServer::start().await;
+        mount_lookup(
+            &server,
+            vec![pull_request(PULL_NUMBER, false, Some(NODE_ID))],
+        )
+        .await;
+        mount_update(&server, false).await;
+
+        test_client(&server, true)?
+            .create_or_update_pull_request(options(false))
+            .await?;
+
+        assert_received_paths(
+            &server,
+            &["/repos/owner/repo/pulls", "/repos/owner/repo/pulls/8"],
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn draft_transition_requires_node_id_after_update() -> Result<()> {
+        let server = MockServer::start().await;
+        mount_lookup(&server, vec![pull_request(PULL_NUMBER, false, None)]).await;
+        mount_update(&server, false).await;
+
+        let error = test_client(&server, true)?
+            .create_or_update_pull_request(options(true))
+            .await
+            .expect_err("missing node ID should fail the draft transition");
+
+        assert!(matches!(
+            error.downcast_ref::<GitHubError>(),
+            Some(GitHubError::MissingPullRequestNodeId {
+                number: PULL_NUMBER
+            })
+        ));
+        assert_received_paths(
+            &server,
+            &["/repos/owner/repo/pulls", "/repos/owner/repo/pulls/8"],
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn graphql_errors_include_draft_transition_context() -> Result<()> {
+        let server = MockServer::start().await;
+        mount_lookup(
+            &server,
+            vec![pull_request(PULL_NUMBER, false, Some(NODE_ID))],
+        )
+        .await;
+        mount_update(&server, false).await;
+        mount_graphql(
+            &server,
+            CONVERT_PULL_REQUEST_TO_DRAFT,
+            json!({ "errors": [{ "message": "Draft pull requests are unavailable" }] }),
+        )
+        .await;
+
+        let error = test_client(&server, true)?
+            .create_or_update_pull_request(options(true))
+            .await
+            .expect_err("GraphQL errors should fail the draft transition");
+        let message = error.to_string();
+
+        assert!(message.contains("Failed to convert GitHub pull request to draft"));
+        assert!(message.contains("Draft pull requests are unavailable"));
+
+        Ok(())
+    }
 }

--- a/crates/seal_github/src/github/mock.rs
+++ b/crates/seal_github/src/github/mock.rs
@@ -2,8 +2,8 @@ use anyhow::Result;
 use chrono::{DateTime, TimeZone, Utc};
 
 use crate::github::{
-    GitHubPullRequest, GitHubPullRequestOptions, GitHubPullRequestReference, GitHubRelease,
-    GitHubService, filter_prs_by_date_range,
+    GitHubError, GitHubPullRequest, GitHubPullRequestOptions, GitHubPullRequestReference,
+    GitHubRelease, GitHubService, filter_prs_by_date_range,
 };
 
 #[derive(Default, Clone)]
@@ -76,6 +76,14 @@ impl MockGithubClient {
 }
 
 impl GitHubService for MockGithubClient {
+    fn ensure_authenticated(&self) -> Result<()> {
+        if std::env::var_os("SEAL_TEST_GITHUB_AUTHENTICATION_REQUIRED").is_some() {
+            return Err(GitHubError::AuthenticationRequired.into());
+        }
+
+        Ok(())
+    }
+
     fn get_latest_release(
         &self,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<GitHubRelease>> + Send + '_>>

--- a/crates/seal_github/src/github/mock.rs
+++ b/crates/seal_github/src/github/mock.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 use chrono::{DateTime, TimeZone, Utc};
 
-use crate::github::{GitHubPullRequest, GitHubRelease, GitHubService, filter_prs_by_date_range};
+use crate::github::{
+    GitHubPullRequest, GitHubPullRequestOptions, GitHubPullRequestReference, GitHubRelease,
+    GitHubService, filter_prs_by_date_range,
+};
 
 #[derive(Default, Clone)]
 pub struct MockGithubClient {
@@ -139,6 +142,30 @@ impl GitHubService for MockGithubClient {
                 prs.truncate(max);
             }
             Ok(prs)
+        })
+    }
+
+    fn create_or_update_pull_request(
+        &self,
+        options: GitHubPullRequestOptions,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<GitHubPullRequestReference>> + Send + '_>,
+    > {
+        Box::pin(async move {
+            let number = if options.title == "Release v1.2.4"
+                && options.body.is_empty()
+                && options.head == "release/v1.2.4"
+                && options.base == "main"
+                && !options.draft
+            {
+                8
+            } else {
+                9
+            };
+
+            Ok(GitHubPullRequestReference {
+                url: format!("https://github.com/owner/repo/pull/{number}"),
+            })
         })
     }
 }

--- a/crates/seal_github/src/lib.rs
+++ b/crates/seal_github/src/lib.rs
@@ -5,6 +5,7 @@ mod helpers;
 pub use helpers::{get_git_remote_url, parse_github_repo};
 
 pub use github::{
-    GitHubClient, GitHubError, GitHubPullRequest, GitHubRelease, GitHubService, MockGithubClient,
+    GitHubClient, GitHubError, GitHubPullRequest, GitHubPullRequestOptions,
+    GitHubPullRequestReference, GitHubRelease, GitHubService, MockGithubClient,
     filter_prs_by_date_range,
 };

--- a/crates/seal_project/src/config.rs
+++ b/crates/seal_project/src/config.rs
@@ -254,7 +254,7 @@ pub struct PullRequestConfig {
     )]
     pub base: Option<String>,
 
-    /// Whether to create the pull request as a draft.
+    /// Whether the pull request should be a draft.
     #[serde(default)]
     #[field(default = "false", value_type = "boolean", example = "draft = true")]
     pub draft: bool,

--- a/crates/seal_project/src/config.rs
+++ b/crates/seal_project/src/config.rs
@@ -203,6 +203,11 @@ pub struct ReleaseConfig {
     "#
     )]
     pub on_pre_commit_failure: PreCommitFailure,
+
+    /// Pull request configuration. The table itself enables pull request creation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[option_group]
+    pub pull_request: Option<PullRequestConfig>,
 }
 
 #[expect(clippy::trivially_copy_pass_by_ref)]
@@ -218,10 +223,77 @@ fn default_confirm() -> bool {
     true
 }
 
+/// Pull request configuration for release bumps.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, OptionsMetadata, Default)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct PullRequestConfig {
+    /// Pull request title template. Supports the `{version}` placeholder.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[field(
+        default = "resolved commit message",
+        value_type = "string",
+        example = r#"title = "Release v{version}""#
+    )]
+    pub title: Option<String>,
+
+    /// Pull request body template. Supports the `{version}` placeholder.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[field(
+        default = "generated changelog section or empty",
+        value_type = "string",
+        example = r#"body = "Prepare release v{version}.""#
+    )]
+    pub body: Option<String>,
+
+    /// Base branch for the pull request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[field(
+        default = "branch from which the release branch was created",
+        value_type = "string",
+        example = r#"base = "main""#
+    )]
+    pub base: Option<String>,
+
+    /// Whether to create the pull request as a draft.
+    #[serde(default)]
+    #[field(default = "false", value_type = "boolean", example = "draft = true")]
+    pub draft: bool,
+}
+
 impl ReleaseConfig {
     fn validate(&self) -> Result<(), ConfigValidationError> {
+        if let Some(pull_request) = &self.pull_request {
+            if self.commit_message.is_none() || self.branch_name.is_none() || !self.push {
+                return Err(ConfigValidationError::PullRequestMissingPrerequisites);
+            }
+
+            pull_request.validate()?;
+        }
+
         if self.push && self.branch_name.is_none() {
             return Err(ConfigValidationError::PushRequiresBranchName);
+        }
+
+        Ok(())
+    }
+}
+
+impl PullRequestConfig {
+    fn validate(&self) -> Result<(), ConfigValidationError> {
+        if self
+            .title
+            .as_ref()
+            .is_some_and(|title| title.trim().is_empty())
+        {
+            return Err(ConfigValidationError::EmptyPullRequestTitle);
+        }
+
+        if self
+            .base
+            .as_ref()
+            .is_some_and(|base| base.trim().is_empty())
+        {
+            return Err(ConfigValidationError::EmptyPullRequestBase);
         }
 
         Ok(())
@@ -533,6 +605,75 @@ version-files = ["VERSION"]
     }
 
     #[test]
+    fn test_parse_pull_request_config() {
+        let toml = r#"
+[release]
+current-version = "1.2.3"
+commit-message = "Release v{version}"
+branch-name = "release/v{version}"
+push = true
+
+[release.pull-request]
+title = "Release v{version}"
+body = "Prepare the release."
+base = "main"
+draft = true
+"#;
+
+        let config = Config::from_toml_str(toml).unwrap();
+        assert_json_snapshot!(config, @r#"
+        {
+          "members": null,
+          "release": {
+            "current-version": "1.2.3",
+            "commit-message": "Release v{version}",
+            "branch-name": "release/v{version}",
+            "push": true,
+            "confirm": true,
+            "pull-request": {
+              "title": "Release v{version}",
+              "body": "Prepare the release.",
+              "base": "main",
+              "draft": true
+            }
+          },
+          "changelog": null
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_parse_empty_pull_request_config_uses_defaults() {
+        let toml = r#"
+[release]
+current-version = "1.2.3"
+commit-message = "Release v{version}"
+branch-name = "release/v{version}"
+push = true
+
+[release.pull-request]
+"#;
+
+        let config = Config::from_toml_str(toml).unwrap();
+        assert_json_snapshot!(config, @r#"
+        {
+          "members": null,
+          "release": {
+            "current-version": "1.2.3",
+            "commit-message": "Release v{version}",
+            "branch-name": "release/v{version}",
+            "push": true,
+            "confirm": true,
+            "pull-request": {
+              "draft": false
+            }
+          },
+          "changelog": null
+        }
+        "#);
+    }
+
+    #[test]
     fn test_parse_empty_config_requires_current_version() {
         let toml = "[release]";
         let result = Config::from_toml_str(toml);
@@ -552,7 +693,7 @@ unknown-field = "value"
         assert_debug_snapshot!(err, @r#"
         ConfigParseError(
             Error {
-                message: "unknown field `unknown-field`, expected one of `current-version`, `version-files`, `commit-message`, `branch-name`, `push`, `confirm`, `pre-commit-commands`, `on-pre-commit-failure`",
+                message: "unknown field `unknown-field`, expected one of `current-version`, `version-files`, `commit-message`, `branch-name`, `push`, `confirm`, `pre-commit-commands`, `on-pre-commit-failure`, `pull-request`",
                 input: Some(
                     "\n[release]\nunknown-field = \"value\"\n",
                 ),
@@ -792,6 +933,7 @@ branch-name = ""
                 confirm: true,
                 pre_commit_commands: None,
                 on_pre_commit_failure: PreCommitFailure::default(),
+                pull_request: None,
             }),
             changelog: None,
         };
@@ -844,6 +986,7 @@ commit-message = "Release {version} with {version} tag"
                     confirm: true,
                     pre_commit_commands: None,
                     on_pre_commit_failure: Abort,
+                    pull_request: None,
                 },
             ),
             changelog: None,
@@ -914,6 +1057,7 @@ version-files = ["Cargo.toml", "package.json", "VERSION"]
                     confirm: true,
                     pre_commit_commands: None,
                     on_pre_commit_failure: Abort,
+                    pull_request: None,
                 },
             ),
             changelog: None,
@@ -945,6 +1089,7 @@ version-files = []
                     confirm: true,
                     pre_commit_commands: None,
                     on_pre_commit_failure: Abort,
+                    pull_request: None,
                 },
             ),
             changelog: None,
@@ -1051,6 +1196,99 @@ push = true
 
         let config = Config::from_toml_str(toml).unwrap();
         assert!(config.release.as_ref().unwrap().push);
+    }
+
+    #[test]
+    fn test_validation_pull_request_requires_release_workflow() {
+        let configs = [
+            r#"
+[release]
+current-version = "1.0.0"
+branch-name = "release/{version}"
+push = true
+
+[release.pull-request]
+"#,
+            r#"
+[release]
+current-version = "1.0.0"
+commit-message = "Release {version}"
+push = true
+
+[release.pull-request]
+"#,
+            r#"
+[release]
+current-version = "1.0.0"
+commit-message = "Release {version}"
+branch-name = "release/{version}"
+
+[release.pull-request]
+"#,
+        ];
+
+        let results = configs.map(Config::from_toml_str);
+        assert_debug_snapshot!(results, @r#"
+        [
+            Err(
+                InvalidConfigurationFile(
+                    PullRequestMissingPrerequisites,
+                ),
+            ),
+            Err(
+                InvalidConfigurationFile(
+                    PullRequestMissingPrerequisites,
+                ),
+            ),
+            Err(
+                InvalidConfigurationFile(
+                    PullRequestMissingPrerequisites,
+                ),
+            ),
+        ]
+        "#);
+    }
+
+    #[test]
+    fn test_validation_pull_request_rejects_empty_title_and_base() {
+        let configs = [
+            r#"
+[release]
+current-version = "1.0.0"
+commit-message = "Release {version}"
+branch-name = "release/{version}"
+push = true
+
+[release.pull-request]
+title = "   "
+"#,
+            r#"
+[release]
+current-version = "1.0.0"
+commit-message = "Release {version}"
+branch-name = "release/{version}"
+push = true
+
+[release.pull-request]
+base = "   "
+"#,
+        ];
+
+        let errors = configs.map(Config::from_toml_str);
+        assert_debug_snapshot!(errors, @r#"
+        [
+            Err(
+                InvalidConfigurationFile(
+                    EmptyPullRequestTitle,
+                ),
+            ),
+            Err(
+                InvalidConfigurationFile(
+                    EmptyPullRequestBase,
+                ),
+            ),
+        ]
+        "#);
     }
 
     #[test]

--- a/crates/seal_project/src/error.rs
+++ b/crates/seal_project/src/error.rs
@@ -63,6 +63,17 @@ pub enum ConfigValidationError {
     #[error("release.push = true requires branch-name to be set")]
     PushRequiresBranchName,
 
+    #[error(
+        "release.pull-request requires release.commit-message, release.branch-name, and release.push = true"
+    )]
+    PullRequestMissingPrerequisites,
+
+    #[error("release.pull-request.title cannot be empty")]
+    EmptyPullRequestTitle,
+
+    #[error("release.pull-request.base cannot be empty")]
+    EmptyPullRequestBase,
+
     #[error("release.changelog.changelog-heading cannot be empty")]
     EmptyChangelogHeading,
 
@@ -116,6 +127,18 @@ mod tests {
             err.to_string(),
             @"release.current-version is not a valid version: ''"
         );
+
+        let err = ConfigValidationError::PullRequestMissingPrerequisites;
+        assert_snapshot!(
+            err.to_string(),
+            @"release.pull-request requires release.commit-message, release.branch-name, and release.push = true"
+        );
+
+        let err = ConfigValidationError::EmptyPullRequestTitle;
+        assert_snapshot!(err.to_string(), @"release.pull-request.title cannot be empty");
+
+        let err = ConfigValidationError::EmptyPullRequestBase;
+        assert_snapshot!(err.to_string(), @"release.pull-request.base cannot be empty");
     }
 
     #[test]

--- a/crates/seal_project/src/git.rs
+++ b/crates/seal_project/src/git.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use anyhow::Context;
+
 use crate::ProjectError;
 
 pub fn find_git_root(start_dir: &Path) -> anyhow::Result<PathBuf> {
@@ -21,6 +23,39 @@ pub fn find_git_root(start_dir: &Path) -> anyhow::Result<PathBuf> {
     Ok(PathBuf::from(path_str))
 }
 
+pub fn get_current_branch(current_directory: &Path) -> anyhow::Result<String> {
+    const COMMAND: &str = "git symbolic-ref --short HEAD";
+
+    let output = Command::new("git")
+        .args(["symbolic-ref", "--short", "HEAD"])
+        .current_dir(current_directory)
+        .output()
+        .context("Failed to determine current Git branch")?;
+
+    if !output.status.success() {
+        return Err(ProjectError::GitCommandFailed {
+            command: COMMAND.to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        }
+        .into());
+    }
+
+    let branch = String::from_utf8(output.stdout)
+        .context("Current Git branch is not valid UTF-8")?
+        .trim()
+        .to_string();
+
+    if branch.is_empty() {
+        return Err(ProjectError::GitCommandFailed {
+            command: COMMAND.to_string(),
+            stderr: "Git returned an empty branch name".to_string(),
+        }
+        .into());
+    }
+
+    Ok(branch)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -29,7 +64,7 @@ mod tests {
 
     fn setup_git_repo(dir: &Path) {
         Command::new("git")
-            .args(["init"])
+            .args(["init", "-b", "main"])
             .current_dir(dir)
             .output()
             .unwrap();
@@ -80,5 +115,49 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let result = find_git_root(temp.path());
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_current_branch() {
+        let temp = TempDir::new().unwrap();
+        let repo_dir = temp.path();
+        setup_git_repo(repo_dir);
+
+        let branch = get_current_branch(repo_dir).unwrap();
+
+        assert_eq!(branch, "main");
+    }
+
+    #[test]
+    fn test_get_current_branch_detached_head() {
+        let temp = TempDir::new().unwrap();
+        let repo_dir = temp.path();
+        setup_git_repo(repo_dir);
+        fs::write(repo_dir.join("README.md"), "# Test").unwrap();
+
+        let add = Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(repo_dir)
+            .output()
+            .unwrap();
+        assert!(add.status.success());
+
+        let commit = Command::new("git")
+            .args(["commit", "-m", "Initial commit"])
+            .current_dir(repo_dir)
+            .output()
+            .unwrap();
+        assert!(commit.status.success());
+
+        let checkout = Command::new("git")
+            .args(["checkout", "--detach"])
+            .current_dir(repo_dir)
+            .output()
+            .unwrap();
+        assert!(checkout.status.success());
+
+        let error = get_current_branch(repo_dir).unwrap_err();
+
+        assert!(error.to_string().contains("git symbolic-ref --short HEAD"));
     }
 }

--- a/crates/seal_project/src/lib.rs
+++ b/crates/seal_project/src/lib.rs
@@ -7,10 +7,10 @@ mod workspace_member;
 
 pub use config::{
     BranchName, ChangelogConfig, ChangelogHeading, CommitMessage, Config, PreCommitFailure,
-    ReleaseConfig, VersionFile, VersionFileTextFormat,
+    PullRequestConfig, ReleaseConfig, VersionFile, VersionFileTextFormat,
 };
 pub use error::{ConfigValidationError, ProjectError};
-pub use git::find_git_root;
+pub use git::{find_git_root, get_current_branch};
 pub use project::ProjectWorkspace;
 pub use project_name::ProjectName;
 pub use workspace_member::WorkspaceMember;

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -370,7 +370,7 @@ Pull request body template. Supports the `{version}` placeholder.
 <span id="release_pull-request_draft"></span>
 #### [`draft`](#release_pull-request_draft)
 
-Whether to create the pull request as a draft.
+Whether the pull request should be a draft.
 
 **Default value**: `false`
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -323,3 +323,87 @@ The version files that need to be updated.
 
 ---
 
+### `release.pull-request`
+
+Pull request configuration for release bumps.
+
+<span id="release_pull-request_base"></span>
+#### [`base`](#release_pull-request_base)
+
+Base branch for the pull request.
+
+**Default value**: `branch from which the release branch was created`
+
+**Type**: `string`
+
+**Example usage**:
+
+=== "seal.toml"
+
+    ```toml
+    [release.pull-request]
+    base = "main"
+    ```
+
+---
+
+<span id="release_pull-request_body"></span>
+#### [`body`](#release_pull-request_body)
+
+Pull request body template. Supports the `{version}` placeholder.
+
+**Default value**: `generated changelog section or empty`
+
+**Type**: `string`
+
+**Example usage**:
+
+=== "seal.toml"
+
+    ```toml
+    [release.pull-request]
+    body = "Prepare release v{version}."
+    ```
+
+---
+
+<span id="release_pull-request_draft"></span>
+#### [`draft`](#release_pull-request_draft)
+
+Whether to create the pull request as a draft.
+
+**Default value**: `false`
+
+**Type**: `boolean`
+
+**Example usage**:
+
+=== "seal.toml"
+
+    ```toml
+    [release.pull-request]
+    draft = true
+    ```
+
+---
+
+<span id="release_pull-request_title"></span>
+#### [`title`](#release_pull-request_title)
+
+Pull request title template. Supports the `{version}` placeholder.
+
+**Default value**: `resolved commit message`
+
+**Type**: `string`
+
+**Example usage**:
+
+=== "seal.toml"
+
+    ```toml
+    [release.pull-request]
+    title = "Release v{version}"
+    ```
+
+---
+

--- a/docs/usage/bumping_versions.md
+++ b/docs/usage/bumping_versions.md
@@ -109,9 +109,9 @@ The table itself enables pull-request creation and requires `commit-message`, `b
 changelog section body or an empty string, `base` defaults to the branch from which the release
 branch was created, and `draft` defaults to `false`. The title and body support `{version}`.
 
-Seal updates an existing open pull request with the same head and base branches instead of creating
-a duplicate. Creating or updating a pull request requires `GITHUB_TOKEN` or `GH_TOKEN` with access
-to the repository.
+Seal updates the title, body, and draft state of an existing open pull request with the same head
+and base branches instead of creating a duplicate. Creating or updating a pull request requires
+`GITHUB_TOKEN` or `GH_TOKEN` with permission to write pull requests in the repository.
 
 ## Pre-Commit Commands
 

--- a/docs/usage/bumping_versions.md
+++ b/docs/usage/bumping_versions.md
@@ -86,6 +86,33 @@ push = true
 
 Both templates must contain `{version}`. `push = true` requires `branch-name`.
 
+## Release Pull Requests
+
+Add a `[release.pull-request]` table to open a pull request after Seal pushes the release branch:
+
+```toml title="seal.toml"
+[release]
+current-version = "1.2.3"
+commit-message = "Release v{version}"
+branch-name = "release/v{version}"
+push = true
+
+[release.pull-request]
+title = "Release v{version}"
+body = "Prepare release v{version}."
+base = "main"
+draft = true
+```
+
+The table itself enables pull-request creation and requires `commit-message`, `branch-name`, and
+`push = true`. `title` defaults to the resolved commit message, `body` defaults to the generated
+changelog section body or an empty string, `base` defaults to the branch from which the release
+branch was created, and `draft` defaults to `false`. The title and body support `{version}`.
+
+Seal updates an existing open pull request with the same head and base branches instead of creating
+a duplicate. Creating or updating a pull request requires `GITHUB_TOKEN` or `GH_TOKEN` with access
+to the repository.
+
 ## Pre-Commit Commands
 
 Use `pre-commit-commands` to run formatters or validation after Seal stages version changes and


### PR DESCRIPTION
## Summary

Add an opt-in `[release.pull-request]` workflow that resolves pull-request metadata, creates or updates the matching GitHub pull request after a successful release-branch push, and prints its URL. This includes configuration validation, dry-run output, changelog-derived bodies, clear authentication failures, integration coverage, and documentation.

Fixes #79.

## Test Plan

`cargo nextest run --all-features`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.
