### PR TITLE
Check Git state before applying a bump

### DIFF
--- a/crates/seal/src/commands/bump.rs
+++ b/crates/seal/src/commands/bump.rs
@@ -1,5 +1,6 @@
 use std::fmt::Write as _;
 use std::io;
+use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
@@ -7,7 +8,10 @@ use seal_bump::{VersionBump, calculate_version_file_changes};
 use seal_command::CommandWrapper;
 use seal_fs::FileResolver;
 use seal_github::{GitHubPullRequestOptions, GitHubService};
-use seal_project::{PreCommitFailure, ProjectWorkspace, get_current_branch};
+use seal_project::{
+    PreCommitFailure, ProjectWorkspace, ReleaseConfig, ensure_clean_worktree,
+    ensure_release_branch_available, get_current_branch,
+};
 
 use seal_cli::BumpArgs;
 
@@ -69,19 +73,26 @@ pub async fn bump(args: &BumpArgs, printer: Printer) -> Result<ExitStatus> {
 
     let file_resolver = FileResolver::new(workspace.root().clone());
 
+    let uses_github =
+        (!args.no_changelog && config.changelog.is_some()) || release_config.pull_request.is_some();
+
     #[cfg(feature = "integration-test")]
-    let github_client: Arc<dyn GitHubService> = {
+    let github_client: Option<Arc<dyn GitHubService>> = if uses_github {
         #[cfg(any(test, feature = "integration-test"))]
         use seal_github::MockGithubClient;
-        Arc::new(MockGithubClient::new())
+        Some(Arc::new(MockGithubClient::new()))
+    } else {
+        None
     };
     #[cfg(not(feature = "integration-test"))]
-    let github_client: Arc<dyn GitHubService> = {
+    let github_client: Option<Arc<dyn GitHubService>> = if uses_github {
         use seal_github::{GitHubClient, get_git_remote_url, parse_github_repo};
 
         let repo_url = get_git_remote_url(workspace.root())?;
         let (owner, repo) = parse_github_repo(&repo_url)?;
-        Arc::new(GitHubClient::new(owner, repo)?)
+        Some(Arc::new(GitHubClient::new(owner, repo)?))
+    } else {
+        None
     };
 
     let mut file_changes = calculate_version_file_changes(
@@ -99,7 +110,9 @@ pub async fn bump(args: &BumpArgs, printer: Printer) -> Result<ExitStatus> {
                 workspace.root(),
                 &new_version_string,
                 changelog_config,
-                &github_client,
+                github_client
+                    .as_ref()
+                    .context("Changelog generation requires a GitHub client")?,
             )
             .await
             .context("Failed to prepare changelog")?;
@@ -213,6 +226,22 @@ pub async fn bump(args: &BumpArgs, printer: Printer) -> Result<ExitStatus> {
         }
     }
 
+    if args.dry_run {
+        let checks = run_bump_preflight(
+            args,
+            release_config,
+            branch_name.as_deref(),
+            github_client.as_deref(),
+            workspace.root(),
+        )?;
+
+        writeln!(stdout, "Preflight checks:")?;
+        for check in checks {
+            writeln!(stdout, "  - {check}")?;
+        }
+        writeln!(stdout)?;
+    }
+
     if !args.dry_run && !commands.is_empty() {
         writeln!(stdout, "Commands to be executed:")?;
 
@@ -258,9 +287,13 @@ pub async fn bump(args: &BumpArgs, printer: Printer) -> Result<ExitStatus> {
         writeln!(stdout)?;
     }
 
-    if pull_request.is_some() {
-        github_client.ensure_authenticated()?;
-    }
+    run_bump_preflight(
+        args,
+        release_config,
+        branch_name.as_deref(),
+        github_client.as_deref(),
+        workspace.root(),
+    )?;
 
     writeln!(stdout, "Updating files...")?;
 
@@ -291,6 +324,8 @@ pub async fn bump(args: &BumpArgs, printer: Printer) -> Result<ExitStatus> {
 
     if let Some(pull_request) = pull_request {
         let pull_request = github_client
+            .as_ref()
+            .context("Pull request creation requires a GitHub client")?
             .create_or_update_pull_request(pull_request)
             .await
             .context("Failed to create or update GitHub pull request")?;
@@ -300,6 +335,56 @@ pub async fn bump(args: &BumpArgs, printer: Printer) -> Result<ExitStatus> {
     writeln!(stdout, "Successfully bumped to {new_version_string}")?;
 
     Ok(ExitStatus::Success)
+}
+
+fn run_bump_preflight(
+    args: &BumpArgs,
+    release_config: &ReleaseConfig,
+    branch_name: Option<&str>,
+    github_client: Option<&dyn GitHubService>,
+    root: &Path,
+) -> Result<Vec<String>> {
+    let mut checks = Vec::new();
+
+    if args.force {
+        checks.push("Working tree and index check skipped (--force)".to_string());
+    } else {
+        ensure_clean_worktree(root)?;
+        checks.push("Working tree and index are clean".to_string());
+    }
+
+    if let Some(branch_name) = branch_name {
+        let remote = "origin";
+        let remote_checked =
+            ensure_release_branch_available(root, branch_name, remote, release_config.push)?;
+        checks.push(format!(
+            "Release branch `{branch_name}` is available locally"
+        ));
+
+        if remote_checked {
+            checks.push(format!("Remote `{remote}` is configured"));
+            checks.push(format!(
+                "Release branch `{branch_name}` is available on `{remote}`"
+            ));
+        }
+    }
+
+    if release_config
+        .pre_commit_commands
+        .as_ref()
+        .is_some_and(|commands| !commands.is_empty())
+    {
+        checks.push("Pre-commit commands have a commit message".to_string());
+    }
+
+    if release_config.pull_request.is_some() {
+        github_client
+            .context("Pull request creation requires a GitHub client")?
+            .ensure_authenticated()?;
+        checks.push("GitHub authentication is available".to_string());
+    }
+
+    Ok(checks)
 }
 
 fn confirm_changes(stdout: &mut impl std::fmt::Write) -> Result<bool> {

--- a/crates/seal/tests/it/bump/custom_formats.rs
+++ b/crates/seal/tests/it/bump/custom_formats.rs
@@ -738,7 +738,7 @@ version = \"0.0.1\"
         )
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").write_stdin("y\n"), @r#"
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch").write_stdin("y\n"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -957,7 +957,7 @@ version = \"0.0.1\"
         )
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").write_stdin("y\n"), @r#"
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch").write_stdin("y\n"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1091,7 +1091,7 @@ version = \"0.0.1\"
         )
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").arg("-v").write_stdin("y\n"), @r#"
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch").arg("-v").write_stdin("y\n"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1175,7 +1175,7 @@ version = \"0.0.1\"
         )
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").arg("-v").write_stdin("y\n"), @r#"
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch").arg("-v").write_stdin("y\n"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----

--- a/crates/seal/tests/it/bump/mod.rs
+++ b/crates/seal/tests/it/bump/mod.rs
@@ -194,7 +194,7 @@ current-version = "1.2.3"
 "#,
     );
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").arg("--dry-run"), @r#"
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch").arg("--dry-run"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -211,6 +211,9 @@ current-version = "1.2.3"
 
     Changes to be made:
       - Update `seal.toml`
+
+    Preflight checks:
+      - Working tree and index check skipped (--force)
 
     Dry run complete. No changes made.
 
@@ -241,7 +244,7 @@ version-files = ["README.md"]
         .write_str("# My Package (1.2.3)")
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").arg("--dry-run"), @r#"
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch").arg("--dry-run"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -265,6 +268,9 @@ version-files = ["README.md"]
     Changes to be made:
       - Update `README.md`
       - Update `seal.toml`
+
+    Preflight checks:
+      - Working tree and index check skipped (--force)
 
     Dry run complete. No changes made.
 
@@ -297,7 +303,7 @@ version-files = ["README.md"]
         .write_str("# My Package (1.2.3)")
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").write_stdin("y\n"), @r#"
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch").write_stdin("y\n"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -603,7 +609,7 @@ commit-message = "Release v{version}"
         .write_str("# My Package (1.2.3)")
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").write_stdin("y\n"), @r#"
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch").write_stdin("y\n"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -680,7 +686,7 @@ confirm = false
         std::fs::set_permissions(hook.path(), permissions).unwrap();
     }
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch"), @r#"
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch"), @r#"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -738,7 +744,7 @@ branch-name = "release/v{version}"
         .write_str("# My Package (1.2.3)")
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").write_stdin("y\n"), @r#"
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch").write_stdin("y\n"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -814,7 +820,7 @@ branch-name = "release/v{version}"
         .write_str("# My Package (1.2.3)")
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").write_stdin("y\n"), @r#"
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch").write_stdin("y\n"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -867,7 +873,7 @@ branch-name = "release/v{version}"
 fn bump_patch_valid_commit_branch_push() {
     let context = TestContext::new();
 
-    context.init_git();
+    context.init_git().init_git_remote();
 
     context.seal_toml(
         r#"
@@ -886,9 +892,9 @@ push = true
         .write_str("# My Package (1.2.3)")
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").write_stdin("y\n"), @r#"
-    success: false
-    exit_code: 2
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch").write_stdin("y\n"), @r#"
+    success: true
+    exit_code: 0
     ----- stdout -----
     Bumping version from 1.2.3 to 1.2.4
 
@@ -926,14 +932,9 @@ push = true
     Executing command: `git add -A`
     Executing command: `git commit -m Release v1.2.4`
     Executing command: `git push origin release/v1.2.4`
+    Successfully bumped to 1.2.4
 
     ----- stderr -----
-    error: Command `git push origin release/v1.2.4` failed (exit code 128)
-    fatal: 'origin' does not appear to be a git repository
-    fatal: Could not read from remote repository.
-
-    Please make sure you have the correct access rights
-    and the repository exists.
     "#);
 
     insta::assert_snapshot!(context.read_file("README.md"), @"# My Package (1.2.4)");
@@ -954,7 +955,7 @@ push = true
 fn bump_patch_valid_commit_branch_push_pr() {
     let context = TestContext::new();
 
-    context.init_git();
+    context.init_git().init_git_remote();
 
     context.seal_toml(
         r#"
@@ -973,9 +974,9 @@ push = true
         .write_str("# My Package (1.2.3)")
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").write_stdin("y\n"), @r#"
-    success: false
-    exit_code: 2
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch").write_stdin("y\n"), @r#"
+    success: true
+    exit_code: 0
     ----- stdout -----
     Bumping version from 1.2.3 to 1.2.4
 
@@ -1013,14 +1014,9 @@ push = true
     Executing command: `git add -A`
     Executing command: `git commit -m Release v1.2.4`
     Executing command: `git push origin release/v1.2.4`
+    Successfully bumped to 1.2.4
 
     ----- stderr -----
-    error: Command `git push origin release/v1.2.4` failed (exit code 128)
-    fatal: 'origin' does not appear to be a git repository
-    fatal: Could not read from remote repository.
-
-    Please make sure you have the correct access rights
-    and the repository exists.
     "#);
 
     insta::assert_snapshot!(context.read_file("README.md"), @"# My Package (1.2.4)");
@@ -1041,7 +1037,7 @@ push = true
 fn bump_patch_valid_commit_branch_push_pr_no_confirm() {
     let context = TestContext::new();
 
-    context.init_git();
+    context.init_git().init_git_remote();
 
     context.seal_toml(
         r#"
@@ -1061,9 +1057,9 @@ confirm = false
         .write_str("# My Package (1.2.3)")
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch"), @r#"
-    success: false
-    exit_code: 2
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch"), @r#"
+    success: true
+    exit_code: 0
     ----- stdout -----
     Bumping version from 1.2.3 to 1.2.4
 
@@ -1100,14 +1096,9 @@ confirm = false
     Executing command: `git add -A`
     Executing command: `git commit -m Release v1.2.4`
     Executing command: `git push origin release/v1.2.4`
+    Successfully bumped to 1.2.4
 
     ----- stderr -----
-    error: Command `git push origin release/v1.2.4` failed (exit code 128)
-    fatal: 'origin' does not appear to be a git repository
-    fatal: Could not read from remote repository.
-
-    Please make sure you have the correct access rights
-    and the repository exists.
     "#);
 
     insta::assert_snapshot!(context.read_file("README.md"), @"# My Package (1.2.4)");
@@ -1129,7 +1120,7 @@ confirm = false
 fn bump_pull_request_not_created_when_push_fails() {
     let context = TestContext::new();
 
-    context.init_git();
+    context.init_git().init_git_remote();
 
     context.seal_toml(
         r#"
@@ -1150,7 +1141,18 @@ push = true
         .write_str("# My Package (1.2.3)")
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").write_stdin("y\n"), @r#"
+    let hook = context.root.child(".git/hooks/pre-push");
+    hook.write_str("#!/bin/sh\necho 'pre-push hook failed' >&2\nexit 1\n")
+        .unwrap();
+
+    #[cfg(unix)]
+    {
+        let mut permissions = std::fs::metadata(hook.path()).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(hook.path(), permissions).unwrap();
+    }
+
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch").write_stdin("y\n"), @r#"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -1199,12 +1201,9 @@ push = true
     Executing command: `git push origin release/v1.2.4`
 
     ----- stderr -----
-    error: Command `git push origin release/v1.2.4` failed (exit code 128)
-    fatal: 'origin' does not appear to be a git repository
-    fatal: Could not read from remote repository.
-
-    Please make sure you have the correct access rights
-    and the repository exists.
+    error: Command `git push origin release/v1.2.4` failed (exit code 1)
+    pre-push hook failed
+    error: failed to push some refs to '[TEMP]/.git/remote.git'
     "#);
 
     insta::assert_snapshot!(context.read_file("README.md"), @"# My Package (1.2.4)");
@@ -1227,7 +1226,7 @@ push = true
 fn bump_pull_request_authentication_failure_makes_no_changes() {
     let context = TestContext::new();
 
-    context.init_git();
+    context.init_git().init_git_remote();
 
     context.seal_toml(
         r#"
@@ -1249,7 +1248,7 @@ confirm = false
         .write_str("# My Package (1.2.3)")
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().env("SEAL_TEST_GITHUB_AUTHENTICATION_REQUIRED", "1").arg("bump").arg("patch"), @r#"
+    seal_snapshot!(context.filters(), context.command().env("SEAL_TEST_GITHUB_AUTHENTICATION_REQUIRED", "1").arg("bump").arg("--force").arg("patch"), @r#"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -1316,7 +1315,7 @@ confirm = false
 fn bump_pull_request_dry_run_prints_defaults() {
     let context = TestContext::new();
 
-    context.init_git();
+    context.init_git().init_git_remote();
 
     context.seal_toml(
         r#"
@@ -1337,7 +1336,7 @@ push = true
         .write_str("# My Package (1.2.3)")
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").arg("--dry-run"), @r#"
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch").arg("--dry-run"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1364,6 +1363,13 @@ push = true
     Changes to be made:
       - Update `README.md`
       - Update `seal.toml`
+
+    Preflight checks:
+      - Working tree and index check skipped (--force)
+      - Release branch `release/v1.2.4` is available locally
+      - Remote `origin` is configured
+      - Release branch `release/v1.2.4` is available on `origin`
+      - GitHub authentication is available
 
     Pull request:
       Title: Release v1.2.4
@@ -1397,7 +1403,7 @@ push = true
 fn bump_pull_request_dry_run_prints_custom_options() {
     let context = TestContext::new();
 
-    context.init_git();
+    context.init_git().init_git_remote();
 
     context.seal_toml(
         r#"
@@ -1414,7 +1420,7 @@ draft = true
 "#,
     );
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").arg("--dry-run"), @r#"
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch").arg("--dry-run"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1435,6 +1441,13 @@ draft = true
 
     Changes to be made:
       - Update `seal.toml`
+
+    Preflight checks:
+      - Working tree and index check skipped (--force)
+      - Release branch `release/v1.2.4` is available locally
+      - Remote `origin` is configured
+      - Release branch `release/v1.2.4` is available on `origin`
+      - GitHub authentication is available
 
     Pull request:
       Title: Ship 1.2.4
@@ -1478,7 +1491,7 @@ confirm = false
         .write_str("# My Package (1.2.3)")
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch"), @r#"
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1567,7 +1580,7 @@ version-files = ["README.md"]
         .write_str("# My Package (1.2.3)")
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("alpha").arg("--dry-run"), @r#"
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("alpha").arg("--dry-run"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1591,6 +1604,9 @@ version-files = ["README.md"]
     Changes to be made:
       - Update `README.md`
       - Update `seal.toml`
+
+    Preflight checks:
+      - Working tree and index check skipped (--force)
 
     Dry run complete. No changes made.
 
@@ -1623,7 +1639,7 @@ version-files = ["README.md"]
         .write_str("# My Package (1.2.3-alpha.0)")
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("alpha").arg("--dry-run"), @r#"
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("alpha").arg("--dry-run"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1647,6 +1663,9 @@ version-files = ["README.md"]
     Changes to be made:
       - Update `README.md`
       - Update `seal.toml`
+
+    Preflight checks:
+      - Working tree and index check skipped (--force)
 
     Dry run complete. No changes made.
 
@@ -1679,7 +1698,7 @@ version-files = ["README.md"]
         .write_str("# My Package (1.2.3-alpha)")
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("alpha").arg("--dry-run"), @r#"
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("alpha").arg("--dry-run"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1703,6 +1722,9 @@ version-files = ["README.md"]
     Changes to be made:
       - Update `README.md`
       - Update `seal.toml`
+
+    Preflight checks:
+      - Working tree and index check skipped (--force)
 
     Dry run complete. No changes made.
 
@@ -1772,7 +1794,7 @@ pre-commit-commands = ["touch pre-commit-ran.txt", "echo done"]
         .write_str("# My Package (1.2.3)")
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").arg("--dry-run"), @r#"
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch").arg("--dry-run"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1798,6 +1820,10 @@ pre-commit-commands = ["touch pre-commit-ran.txt", "echo done"]
     Changes to be made:
       - Update `README.md`
       - Update `seal.toml`
+
+    Preflight checks:
+      - Working tree and index check skipped (--force)
+      - Pre-commit commands have a commit message
 
     Dry run complete. No changes made.
 
@@ -1830,7 +1856,7 @@ pre-commit-commands = ["touch pre-commit-ran.txt"]
         .write_str("# My Package (1.2.3)")
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").write_stdin("y\n"), @r#"
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch").write_stdin("y\n"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1903,7 +1929,7 @@ confirm = false
         .write_str("# My Package (1.2.3)")
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch"), @r#"
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -1976,7 +2002,7 @@ confirm = false
         .write_str("# My Package (1.2.3)")
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch"), @r#"
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch"), @r#"
     success: false
     exit_code: 2
     ----- stdout -----
@@ -2045,7 +2071,7 @@ confirm = false
         .write_str("# My Package (1.2.3)")
         .unwrap();
 
-    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch"), @r#"
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("--force").arg("patch"), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -2096,4 +2122,457 @@ confirm = false
     assert!(context.root.join("success.txt").exists());
     insta::assert_snapshot!(context.git_current_branch(), @"main");
     insta::assert_snapshot!(context.git_last_commit_message(), @"Release v1.2.4");
+}
+
+#[test]
+fn bump_dirty_worktree_fails_without_changes() {
+    let context = TestContext::new();
+
+    context.seal_toml(
+        r#"
+[release]
+current-version = "1.2.3"
+confirm = false
+"#,
+    );
+    context.init_git();
+    context
+        .root
+        .child("notes.txt")
+        .write_str("unfinished work")
+        .unwrap();
+
+    let config_before = context.read_file("seal.toml");
+    let status_before = context.git_status();
+
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch"), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+    Bumping version from 1.2.3 to 1.2.4
+
+    Preview of changes:
+    ────────────────────────────────────────────────────────────────────────────────
+    Source: seal.toml
+    ────────────┬───────────────────────────────────────────────────────────────────
+        1     1 │ [release]
+        2       │-current-version = "1.2.3"
+              2 │+current-version = "1.2.4"
+        3     3 │ confirm = false
+    ────────────┴───────────────────────────────────────────────────────────────────
+
+    Changes to be made:
+      - Update `seal.toml`
+
+
+    ----- stderr -----
+    error: Working tree and index are not clean:
+      ?? notes.txt
+    Commit or stash these changes before running `seal bump`, or use `--force` to bypass this check.
+    "#);
+
+    assert_eq!(context.read_file("seal.toml"), config_before);
+    assert_eq!(context.git_status(), status_before);
+    assert_eq!(context.git_current_branch(), "main");
+    assert_eq!(context.git_last_commit_message(), "Initial commit");
+}
+
+#[test]
+fn bump_force_dry_run_reports_skipped_cleanliness_check() {
+    let context = TestContext::new();
+
+    context.seal_toml(
+        r#"
+[release]
+current-version = "1.2.3"
+"#,
+    );
+    context.init_git();
+    context
+        .root
+        .child("notes.txt")
+        .write_str("unfinished work")
+        .unwrap();
+
+    let status_before = context.git_status();
+
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").arg("--force").arg("--dry-run"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Bumping version from 1.2.3 to 1.2.4
+
+    Preview of changes:
+    ────────────────────────────────────────────────────────────────────────────────
+    Source: seal.toml
+    ────────────┬───────────────────────────────────────────────────────────────────
+        1     1 │ [release]
+        2       │-current-version = "1.2.3"
+              2 │+current-version = "1.2.4"
+    ────────────┴───────────────────────────────────────────────────────────────────
+
+    Changes to be made:
+      - Update `seal.toml`
+
+    Preflight checks:
+      - Working tree and index check skipped (--force)
+
+    Dry run complete. No changes made.
+
+    ----- stderr -----
+    "#);
+
+    assert_eq!(context.git_status(), status_before);
+    assert_eq!(context.read_file("notes.txt"), "unfinished work");
+}
+
+#[test]
+fn bump_existing_local_release_branch_fails_without_changes() {
+    let context = TestContext::new();
+
+    context.seal_toml(
+        r#"
+[release]
+current-version = "1.2.3"
+branch-name = "release/v{version}"
+confirm = false
+"#,
+    );
+    context.init_git();
+
+    let branch = std::process::Command::new("git")
+        .args(["branch", "release/v1.2.4"])
+        .current_dir(context.root.path())
+        .output()
+        .expect("Failed to create release branch");
+    assert!(branch.status.success());
+
+    let config_before = context.read_file("seal.toml");
+    let status_before = context.git_status();
+
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch"), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+    Bumping version from 1.2.3 to 1.2.4
+
+    Preview of changes:
+    ────────────────────────────────────────────────────────────────────────────────
+    Source: seal.toml
+    ────────────┬───────────────────────────────────────────────────────────────────
+        1     1 │ [release]
+        2       │-current-version = "1.2.3"
+              2 │+current-version = "1.2.4"
+        3     3 │ branch-name = "release/v{version}"
+        4     4 │ confirm = false
+    ────────────┴───────────────────────────────────────────────────────────────────
+
+    Changes to be made:
+      - Update `seal.toml`
+
+    Commands to be executed:
+      `git checkout -b release/v1.2.4`
+
+
+    ----- stderr -----
+    error: Release branch `release/v1.2.4` already exists locally
+    "#);
+
+    assert_eq!(context.read_file("seal.toml"), config_before);
+    assert_eq!(context.git_status(), status_before);
+    assert_eq!(context.git_current_branch(), "main");
+    assert!(context.git_branch_exists("release/v1.2.4"));
+}
+
+#[test]
+fn bump_existing_remote_release_branch_fails_without_changes() {
+    let context = TestContext::new();
+
+    context.seal_toml(
+        r#"
+[release]
+current-version = "1.2.3"
+branch-name = "release/v{version}"
+confirm = false
+"#,
+    );
+    context.init_git().init_git_remote();
+
+    let push = std::process::Command::new("git")
+        .args(["push", "origin", "HEAD:refs/heads/release/v1.2.4"])
+        .current_dir(context.root.path())
+        .output()
+        .expect("Failed to create remote release branch");
+    assert!(push.status.success());
+
+    let config_before = context.read_file("seal.toml");
+    let status_before = context.git_status();
+
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch"), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+    Bumping version from 1.2.3 to 1.2.4
+
+    Preview of changes:
+    ────────────────────────────────────────────────────────────────────────────────
+    Source: seal.toml
+    ────────────┬───────────────────────────────────────────────────────────────────
+        1     1 │ [release]
+        2       │-current-version = "1.2.3"
+              2 │+current-version = "1.2.4"
+        3     3 │ branch-name = "release/v{version}"
+        4     4 │ confirm = false
+    ────────────┴───────────────────────────────────────────────────────────────────
+
+    Changes to be made:
+      - Update `seal.toml`
+
+    Commands to be executed:
+      `git checkout -b release/v1.2.4`
+
+
+    ----- stderr -----
+    error: Release branch `release/v1.2.4` already exists on remote `origin`
+    "#);
+
+    assert_eq!(context.read_file("seal.toml"), config_before);
+    assert_eq!(context.git_status(), status_before);
+    assert_eq!(context.git_current_branch(), "main");
+    assert!(!context.git_branch_exists("release/v1.2.4"));
+
+    let remote_branch = std::process::Command::new("git")
+        .args([
+            "ls-remote",
+            "--exit-code",
+            "--heads",
+            "origin",
+            "refs/heads/release/v1.2.4",
+        ])
+        .current_dir(context.root.path())
+        .output()
+        .expect("Failed to inspect remote release branch");
+    assert!(remote_branch.status.success());
+}
+
+#[test]
+fn bump_push_requires_origin_without_changes() {
+    let context = TestContext::new();
+
+    context.seal_toml(
+        r#"
+[release]
+current-version = "1.2.3"
+branch-name = "release/v{version}"
+push = true
+confirm = false
+"#,
+    );
+    context.init_git();
+
+    let config_before = context.read_file("seal.toml");
+    let status_before = context.git_status();
+
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch"), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+    Bumping version from 1.2.3 to 1.2.4
+
+    Preview of changes:
+    ────────────────────────────────────────────────────────────────────────────────
+    Source: seal.toml
+    ────────────┬───────────────────────────────────────────────────────────────────
+        1     1 │ [release]
+        2       │-current-version = "1.2.3"
+              2 │+current-version = "1.2.4"
+        3     3 │ branch-name = "release/v{version}"
+        4     4 │ push = true
+        5     5 │ confirm = false
+    ────────────┴───────────────────────────────────────────────────────────────────
+
+    Changes to be made:
+      - Update `seal.toml`
+
+    Commands to be executed:
+      `git checkout -b release/v1.2.4`
+      `git push origin release/v1.2.4`
+
+
+    ----- stderr -----
+    error: No `origin` Git remote is configured; release.push = true requires one
+    "#);
+
+    assert_eq!(context.read_file("seal.toml"), config_before);
+    assert_eq!(context.git_status(), status_before);
+    assert_eq!(context.git_current_branch(), "main");
+    assert!(!context.git_branch_exists("release/v1.2.4"));
+}
+
+#[test]
+fn bump_pull_request_dry_run_requires_authentication() {
+    let context = TestContext::new();
+
+    context.seal_toml(
+        r#"
+[release]
+current-version = "1.2.3"
+commit-message = "Release v{version}"
+branch-name = "release/v{version}"
+push = true
+[release.pull-request]
+"#,
+    );
+    context.init_git().init_git_remote();
+
+    let config_before = context.read_file("seal.toml");
+    let status_before = context.git_status();
+
+    seal_snapshot!(context.filters(), context.command().env("SEAL_TEST_GITHUB_AUTHENTICATION_REQUIRED", "1").arg("bump").arg("patch").arg("--dry-run"), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+    Bumping version from 1.2.3 to 1.2.4
+
+    Preview of changes:
+    ────────────────────────────────────────────────────────────────────────────────
+    Source: seal.toml
+    ────────────┬───────────────────────────────────────────────────────────────────
+        1     1 │ [release]
+        2       │-current-version = "1.2.3"
+              2 │+current-version = "1.2.4"
+        3     3 │ commit-message = "Release v{version}"
+        4     4 │ branch-name = "release/v{version}"
+        5     5 │ push = true
+        6     6 │ [release.pull-request]
+    ────────────┴───────────────────────────────────────────────────────────────────
+
+    Changes to be made:
+      - Update `seal.toml`
+
+
+    ----- stderr -----
+    error: GitHub authentication is required; set GITHUB_TOKEN or GH_TOKEN
+    "#);
+
+    assert_eq!(context.read_file("seal.toml"), config_before);
+    assert_eq!(context.git_status(), status_before);
+    assert_eq!(context.git_current_branch(), "main");
+    assert!(!context.git_branch_exists("release/v1.2.4"));
+}
+
+#[test]
+fn bump_dry_run_reports_preflight_checks() {
+    let context = TestContext::new();
+
+    context.seal_toml(
+        r#"
+[release]
+current-version = "1.2.3"
+commit-message = "Release v{version}"
+branch-name = "release/v{version}"
+push = true
+pre-commit-commands = ["cargo fmt"]
+[release.pull-request]
+"#,
+    );
+    context.init_git().init_git_remote();
+
+    let status_before = context.git_status();
+
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch").arg("--dry-run"), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Bumping version from 1.2.3 to 1.2.4
+
+    Preview of changes:
+    ────────────────────────────────────────────────────────────────────────────────
+    Source: seal.toml
+    ────────────┬───────────────────────────────────────────────────────────────────
+        1     1 │ [release]
+        2       │-current-version = "1.2.3"
+              2 │+current-version = "1.2.4"
+        3     3 │ commit-message = "Release v{version}"
+        4     4 │ branch-name = "release/v{version}"
+        5     5 │ push = true
+        6     6 │ pre-commit-commands = ["cargo fmt"]
+    ────────────┴───────────────────────────────────────────────────────────────────
+
+    Changes to be made:
+      - Update `seal.toml`
+
+    Preflight checks:
+      - Working tree and index are clean
+      - Release branch `release/v1.2.4` is available locally
+      - Remote `origin` is configured
+      - Release branch `release/v1.2.4` is available on `origin`
+      - Pre-commit commands have a commit message
+      - GitHub authentication is available
+
+    Pull request:
+      Title: Release v1.2.4
+      Head: release/v1.2.4
+      Base: main
+      Draft: false
+      Body: (empty)
+
+    Dry run complete. No changes made.
+
+    ----- stderr -----
+    "#);
+
+    assert_eq!(context.git_status(), status_before);
+    assert_eq!(context.git_current_branch(), "main");
+    assert!(!context.git_branch_exists("release/v1.2.4"));
+}
+
+#[test]
+fn bump_invalid_resolved_branch_fails_without_changes() {
+    let context = TestContext::new();
+
+    context.seal_toml(
+        r#"
+[release]
+current-version = "1.2.3"
+branch-name = "release/{version} invalid"
+confirm = false
+"#,
+    );
+    context.init_git();
+
+    let config_before = context.read_file("seal.toml");
+    let status_before = context.git_status();
+
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("patch"), @r#"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+    Bumping version from 1.2.3 to 1.2.4
+
+    Preview of changes:
+    ────────────────────────────────────────────────────────────────────────────────
+    Source: seal.toml
+    ────────────┬───────────────────────────────────────────────────────────────────
+        1     1 │ [release]
+        2       │-current-version = "1.2.3"
+              2 │+current-version = "1.2.4"
+        3     3 │ branch-name = "release/{version} invalid"
+        4     4 │ confirm = false
+    ────────────┴───────────────────────────────────────────────────────────────────
+
+    Changes to be made:
+      - Update `seal.toml`
+
+    Commands to be executed:
+      `git checkout -b release/1.2.4 invalid`
+
+
+    ----- stderr -----
+    error: Release branch `release/1.2.4 invalid` is not a valid Git branch name
+    "#);
+
+    assert_eq!(context.read_file("seal.toml"), config_before);
+    assert_eq!(context.git_status(), status_before);
+    assert_eq!(context.git_current_branch(), "main");
 }

--- a/crates/seal/tests/it/common/mod.rs
+++ b/crates/seal/tests/it/common/mod.rs
@@ -247,6 +247,19 @@ current-version = "{version}"
         output.status.success()
     }
 
+    /// Get the working tree and index status.
+    pub fn git_status(&self) -> String {
+        let output = std::process::Command::new("git")
+            .args(["status", "--porcelain=v1", "--untracked-files=all"])
+            .current_dir(self.root.path())
+            .output()
+            .expect("Failed to get git status");
+
+        assert!(output.status.success(), "Failed to get git status");
+
+        String::from_utf8(output.stdout).expect("Invalid UTF-8")
+    }
+
     pub fn merge_current_branch_and_checkout_main(&self) {
         let current_branch = self.git_current_branch();
 

--- a/crates/seal_cli/src/lib.rs
+++ b/crates/seal_cli/src/lib.rs
@@ -152,13 +152,17 @@ pub struct BumpArgs {
     /// Version bump to perform (e.g., 'major', 'minor', 'patch', 'alpha', 'major-beta', or '1.2.3')
     pub version: String,
 
-    /// Show what would be done without making any changes
+    /// Run preflight checks and show what would be done without making changes
     #[arg(long)]
     pub dry_run: bool,
 
     /// Skip generating or updating the changelog
     #[arg(long)]
     pub no_changelog: bool,
+
+    /// Bypass the clean working tree and index check
+    #[arg(long)]
+    pub force: bool,
 }
 
 #[derive(Args, Debug)]

--- a/crates/seal_project/src/config.rs
+++ b/crates/seal_project/src/config.rs
@@ -181,13 +181,15 @@ pub struct ReleaseConfig {
     )]
     pub confirm: bool,
 
-    /// Commands to run before committing. These run after `git add -A` and before `git commit`.
-    /// A second `git add -A` is run after these commands to stage any changes they make.
+    /// Commands to run before committing. A non-empty list requires `commit-message`. These run
+    /// after `git add -A` and before `git commit`. A second `git add -A` is run after these commands
+    /// to stage any changes they make.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[field(
         default = "[]",
         value_type = "list",
         example = r#"
+        commit-message = "Release {version}"
         pre-commit-commands = ["cargo fmt", "npm run lint:fix"]
     "#
     )]
@@ -262,6 +264,15 @@ pub struct PullRequestConfig {
 
 impl ReleaseConfig {
     fn validate(&self) -> Result<(), ConfigValidationError> {
+        if self.commit_message.is_none()
+            && self
+                .pre_commit_commands
+                .as_ref()
+                .is_some_and(|commands| !commands.is_empty())
+        {
+            return Err(ConfigValidationError::PreCommitCommandsRequireCommitMessage);
+        }
+
         if let Some(pull_request) = &self.pull_request {
             if self.commit_message.is_none() || self.branch_name.is_none() || !self.push {
                 return Err(ConfigValidationError::PullRequestMissingPrerequisites);
@@ -1196,6 +1207,34 @@ push = true
 
         let config = Config::from_toml_str(toml).unwrap();
         assert!(config.release.as_ref().unwrap().push);
+    }
+
+    #[test]
+    fn test_validation_pre_commit_commands_require_commit_message() {
+        let toml = r#"
+[release]
+current-version = "1.0.0"
+pre-commit-commands = ["cargo fmt"]
+"#;
+
+        let result = Config::from_toml_str(toml);
+
+        assert_debug_snapshot!(result.unwrap_err(), @r#"
+        InvalidConfigurationFile(
+            PreCommitCommandsRequireCommitMessage,
+        )
+        "#);
+    }
+
+    #[test]
+    fn test_validation_empty_pre_commit_commands_do_not_require_commit_message() {
+        let toml = r#"
+[release]
+current-version = "1.0.0"
+pre-commit-commands = []
+"#;
+
+        assert!(Config::from_toml_str(toml).is_ok());
     }
 
     #[test]

--- a/crates/seal_project/src/error.rs
+++ b/crates/seal_project/src/error.rs
@@ -25,6 +25,23 @@ pub enum ProjectError {
     #[error("Git command '{command}' failed: {stderr}")]
     GitCommandFailed { command: String, stderr: String },
 
+    #[error(
+        "Working tree and index are not clean:\n{changes}\nCommit or stash these changes before running `seal bump`, or use `--force` to bypass this check."
+    )]
+    DirtyGitState { changes: String },
+
+    #[error("Release branch `{branch}` is not a valid Git branch name")]
+    InvalidGitBranch { branch: String },
+
+    #[error("Release branch `{branch}` already exists locally")]
+    LocalGitBranchExists { branch: String },
+
+    #[error("No `{remote}` Git remote is configured; release.push = true requires one")]
+    MissingGitRemote { remote: String },
+
+    #[error("Release branch `{branch}` already exists on remote `{remote}`")]
+    RemoteGitBranchExists { branch: String, remote: String },
+
     #[error("Workspace member '{member}' is missing seal.toml at path: {path}")]
     MemberMissingSealToml { member: String, path: PathBuf },
 
@@ -62,6 +79,9 @@ pub enum ConfigValidationError {
 
     #[error("release.push = true requires branch-name to be set")]
     PushRequiresBranchName,
+
+    #[error("release.pre-commit-commands requires release.commit-message to be set")]
+    PreCommitCommandsRequireCommitMessage,
 
     #[error(
         "release.pull-request requires release.commit-message, release.branch-name, and release.push = true"
@@ -149,5 +169,50 @@ mod tests {
             project_err.to_string(),
             @"Invalid configuration file: release.commit-message cannot be empty"
         );
+    }
+
+    #[test]
+    fn test_dirty_git_state_error_display() {
+        let error = ProjectError::DirtyGitState {
+            changes: "  M src/lib.rs".to_string(),
+        };
+        assert_snapshot!(error.to_string(), @r#"
+        Working tree and index are not clean:
+          M src/lib.rs
+        Commit or stash these changes before running `seal bump`, or use `--force` to bypass this check.
+        "#);
+    }
+
+    #[test]
+    fn test_invalid_git_branch_error_display() {
+        let error = ProjectError::InvalidGitBranch {
+            branch: "bad branch".to_string(),
+        };
+        assert_snapshot!(error.to_string(), @"Release branch `bad branch` is not a valid Git branch name");
+    }
+
+    #[test]
+    fn test_local_git_branch_exists_error_display() {
+        let error = ProjectError::LocalGitBranchExists {
+            branch: "release/v1.2.3".to_string(),
+        };
+        assert_snapshot!(error.to_string(), @"Release branch `release/v1.2.3` already exists locally");
+    }
+
+    #[test]
+    fn test_missing_git_remote_error_display() {
+        let error = ProjectError::MissingGitRemote {
+            remote: "origin".to_string(),
+        };
+        assert_snapshot!(error.to_string(), @"No `origin` Git remote is configured; release.push = true requires one");
+    }
+
+    #[test]
+    fn test_remote_git_branch_exists_error_display() {
+        let error = ProjectError::RemoteGitBranchExists {
+            branch: "release/v1.2.3".to_string(),
+            remote: "origin".to_string(),
+        };
+        assert_snapshot!(error.to_string(), @"Release branch `release/v1.2.3` already exists on remote `origin`");
     }
 }

--- a/crates/seal_project/src/git.rs
+++ b/crates/seal_project/src/git.rs
@@ -56,6 +56,148 @@ pub fn get_current_branch(current_directory: &Path) -> anyhow::Result<String> {
     Ok(branch)
 }
 
+pub fn ensure_clean_worktree(current_directory: &Path) -> anyhow::Result<()> {
+    const COMMAND: &str = "git --no-optional-locks status --porcelain=v1 --untracked-files=all --ignore-submodules=none";
+
+    let output = Command::new("git")
+        .args([
+            "--no-optional-locks",
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            "--ignore-submodules=none",
+        ])
+        .current_dir(current_directory)
+        .output()
+        .context("Failed to inspect Git state")?;
+
+    if !output.status.success() {
+        return Err(ProjectError::GitCommandFailed {
+            command: COMMAND.to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        }
+        .into());
+    }
+
+    let status = String::from_utf8(output.stdout).context("Git status is not valid UTF-8")?;
+    if !status.is_empty() {
+        let changes = status
+            .trim_end()
+            .lines()
+            .map(|line| format!("  {line}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        return Err(ProjectError::DirtyGitState { changes }.into());
+    }
+
+    Ok(())
+}
+
+pub fn ensure_release_branch_available(
+    current_directory: &Path,
+    branch: &str,
+    remote: &str,
+    require_remote: bool,
+) -> anyhow::Result<bool> {
+    let validated_branch = Command::new("git")
+        .args(["check-ref-format", "--branch", branch])
+        .current_dir(current_directory)
+        .output()
+        .context("Failed to validate release branch name")?;
+    let validated_branch_name = String::from_utf8_lossy(&validated_branch.stdout);
+
+    if !validated_branch.status.success()
+        || validated_branch_name.trim() != branch
+        || branch == "HEAD"
+    {
+        return Err(ProjectError::InvalidGitBranch {
+            branch: branch.to_string(),
+        }
+        .into());
+    }
+
+    let local_ref = format!("refs/heads/{branch}");
+    let local = Command::new("git")
+        .args(["show-ref", "--verify", "--quiet", &local_ref])
+        .current_dir(current_directory)
+        .output()
+        .context("Failed to inspect local Git branches")?;
+
+    match local.status.code() {
+        Some(0) => {
+            return Err(ProjectError::LocalGitBranchExists {
+                branch: branch.to_string(),
+            }
+            .into());
+        }
+        Some(1) => {}
+        _ => {
+            return Err(ProjectError::GitCommandFailed {
+                command: format!("git show-ref --verify --quiet {local_ref}"),
+                stderr: String::from_utf8_lossy(&local.stderr).trim().to_string(),
+            }
+            .into());
+        }
+    }
+
+    let remote_urls = Command::new("git")
+        .args(["remote", "get-url", "--push", "--all", remote])
+        .current_dir(current_directory)
+        .output()
+        .context("Failed to inspect Git remotes")?;
+
+    if !remote_urls.status.success() || remote_urls.stdout.is_empty() {
+        if require_remote {
+            return Err(ProjectError::MissingGitRemote {
+                remote: remote.to_string(),
+            }
+            .into());
+        }
+
+        return Ok(false);
+    }
+
+    let remote_ref = format!("refs/heads/{branch}");
+    let remote_urls =
+        String::from_utf8(remote_urls.stdout).context("Git remote URLs are not valid UTF-8")?;
+
+    for remote_url in remote_urls.lines() {
+        let remote_branch = Command::new("git")
+            .args([
+                "ls-remote",
+                "--exit-code",
+                "--heads",
+                remote_url,
+                &remote_ref,
+            ])
+            .current_dir(current_directory)
+            .output()
+            .context("Failed to inspect remote Git branches")?;
+
+        match remote_branch.status.code() {
+            Some(0) => {
+                return Err(ProjectError::RemoteGitBranchExists {
+                    branch: branch.to_string(),
+                    remote: remote.to_string(),
+                }
+                .into());
+            }
+            Some(2) => {}
+            _ => {
+                return Err(ProjectError::GitCommandFailed {
+                    command: format!("git ls-remote --exit-code --heads {remote} {remote_ref}"),
+                    stderr: String::from_utf8_lossy(&remote_branch.stderr)
+                        .trim()
+                        .to_string(),
+                }
+                .into());
+            }
+        }
+    }
+
+    Ok(true)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -80,6 +222,24 @@ mod tests {
             .current_dir(dir)
             .output()
             .unwrap();
+    }
+
+    fn commit_file(dir: &Path) {
+        fs::write(dir.join("README.md"), "# Test").unwrap();
+
+        let add = Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        assert!(add.status.success());
+
+        let commit = Command::new("git")
+            .args(["commit", "-m", "Initial commit"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        assert!(commit.status.success());
     }
 
     #[test]
@@ -159,5 +319,180 @@ mod tests {
         let error = get_current_branch(repo_dir).unwrap_err();
 
         assert!(error.to_string().contains("git symbolic-ref --short HEAD"));
+    }
+
+    #[test]
+    fn test_ensure_clean_worktree_rejects_untracked_file() {
+        let temp = TempDir::new().unwrap();
+        setup_git_repo(temp.path());
+        assert!(ensure_clean_worktree(temp.path()).is_ok());
+
+        fs::write(temp.path().join("untracked.txt"), "change").unwrap();
+        let error = ensure_clean_worktree(temp.path()).unwrap_err();
+
+        assert!(matches!(
+            error.downcast_ref::<ProjectError>(),
+            Some(ProjectError::DirtyGitState { changes }) if changes.contains("?? untracked.txt")
+        ));
+    }
+
+    #[test]
+    fn test_ensure_clean_worktree_rejects_staged_file() {
+        let temp = TempDir::new().unwrap();
+        setup_git_repo(temp.path());
+        fs::write(temp.path().join("staged.txt"), "change").unwrap();
+        let add = Command::new("git")
+            .args(["add", "staged.txt"])
+            .current_dir(temp.path())
+            .output()
+            .unwrap();
+        assert!(add.status.success());
+
+        let error = ensure_clean_worktree(temp.path()).unwrap_err();
+
+        assert!(matches!(
+            error.downcast_ref::<ProjectError>(),
+            Some(ProjectError::DirtyGitState { changes }) if changes.contains("A  staged.txt")
+        ));
+    }
+
+    #[test]
+    fn test_ensure_release_branch_available_rejects_invalid_branch() {
+        let temp = TempDir::new().unwrap();
+        setup_git_repo(temp.path());
+
+        let error =
+            ensure_release_branch_available(temp.path(), "release/invalid branch", "origin", false)
+                .unwrap_err();
+
+        assert!(matches!(
+            error.downcast_ref::<ProjectError>(),
+            Some(ProjectError::InvalidGitBranch { branch }) if branch == "release/invalid branch"
+        ));
+    }
+
+    #[test]
+    fn test_ensure_release_branch_available_rejects_local_branch() {
+        let temp = TempDir::new().unwrap();
+        setup_git_repo(temp.path());
+        commit_file(temp.path());
+
+        let error =
+            ensure_release_branch_available(temp.path(), "main", "origin", false).unwrap_err();
+
+        assert!(matches!(
+            error.downcast_ref::<ProjectError>(),
+            Some(ProjectError::LocalGitBranchExists { branch }) if branch == "main"
+        ));
+        let remote_checked =
+            ensure_release_branch_available(temp.path(), "release/v1.2.3", "origin", false)
+                .unwrap();
+        assert!(!remote_checked);
+    }
+
+    #[test]
+    fn test_ensure_release_branch_available_requires_remote() {
+        let temp = TempDir::new().unwrap();
+        setup_git_repo(temp.path());
+        commit_file(temp.path());
+
+        let error = ensure_release_branch_available(temp.path(), "release/v1.2.3", "origin", true)
+            .unwrap_err();
+
+        assert!(matches!(
+            error.downcast_ref::<ProjectError>(),
+            Some(ProjectError::MissingGitRemote { remote }) if remote == "origin"
+        ));
+    }
+
+    #[test]
+    fn test_ensure_release_branch_available_rejects_remote_branch() {
+        let temp = TempDir::new().unwrap();
+        setup_git_repo(temp.path());
+        commit_file(temp.path());
+        let remote = temp.path().join("remote.git");
+        let init_remote = Command::new("git")
+            .args(["init", "--bare"])
+            .arg(&remote)
+            .output()
+            .unwrap();
+        assert!(init_remote.status.success());
+        let add_remote = Command::new("git")
+            .args(["remote", "add", "origin"])
+            .arg(&remote)
+            .current_dir(temp.path())
+            .output()
+            .unwrap();
+        assert!(add_remote.status.success());
+        let push = Command::new("git")
+            .args(["push", "origin", "HEAD:refs/heads/release/v1.2.3"])
+            .current_dir(temp.path())
+            .output()
+            .unwrap();
+        assert!(push.status.success());
+
+        let error = ensure_release_branch_available(temp.path(), "release/v1.2.3", "origin", false)
+            .unwrap_err();
+
+        assert!(matches!(
+            error.downcast_ref::<ProjectError>(),
+            Some(ProjectError::RemoteGitBranchExists { branch, remote })
+                if branch == "release/v1.2.3" && remote == "origin"
+        ));
+        assert!(
+            ensure_release_branch_available(temp.path(), "release/v1.2.4", "origin", true).is_ok()
+        );
+    }
+
+    #[test]
+    fn test_ensure_release_branch_available_checks_push_url() {
+        let temp = TempDir::new().unwrap();
+        setup_git_repo(temp.path());
+        commit_file(temp.path());
+        let fetch_remote = temp.path().join("fetch.git");
+        let push_remote = temp.path().join("push.git");
+
+        for remote in [&fetch_remote, &push_remote] {
+            let init_remote = Command::new("git")
+                .args(["init", "--bare"])
+                .arg(remote)
+                .output()
+                .unwrap();
+            assert!(init_remote.status.success());
+        }
+
+        let add_remote = Command::new("git")
+            .args(["remote", "add", "origin"])
+            .arg(&fetch_remote)
+            .current_dir(temp.path())
+            .output()
+            .unwrap();
+        assert!(add_remote.status.success());
+
+        let set_push_url = Command::new("git")
+            .args(["remote", "set-url", "--push", "origin"])
+            .arg(&push_remote)
+            .current_dir(temp.path())
+            .output()
+            .unwrap();
+        assert!(set_push_url.status.success());
+
+        let push = Command::new("git")
+            .arg("push")
+            .arg(&push_remote)
+            .args(["HEAD:refs/heads/release/v1.2.3"])
+            .current_dir(temp.path())
+            .output()
+            .unwrap();
+        assert!(push.status.success());
+
+        let error = ensure_release_branch_available(temp.path(), "release/v1.2.3", "origin", true)
+            .unwrap_err();
+
+        assert!(matches!(
+            error.downcast_ref::<ProjectError>(),
+            Some(ProjectError::RemoteGitBranchExists { branch, remote })
+                if branch == "release/v1.2.3" && remote == "origin"
+        ));
     }
 }

--- a/crates/seal_project/src/lib.rs
+++ b/crates/seal_project/src/lib.rs
@@ -10,7 +10,9 @@ pub use config::{
     PullRequestConfig, ReleaseConfig, VersionFile, VersionFileTextFormat,
 };
 pub use error::{ConfigValidationError, ProjectError};
-pub use git::{find_git_root, get_current_branch};
+pub use git::{
+    ensure_clean_worktree, ensure_release_branch_available, find_git_root, get_current_branch,
+};
 pub use project::ProjectWorkspace;
 pub use project_name::ProjectName;
 pub use workspace_member::WorkspaceMember;

--- a/docs/get-started/quick-start.md
+++ b/docs/get-started/quick-start.md
@@ -22,6 +22,9 @@ This updates `package.version` without replacing unrelated occurrences of `0.1.0
 seal validate config
 ```
 
+Commit `seal.toml` and any version-file changes before previewing; version bumps require a clean
+working tree and index by default.
+
 ## Preview a Version Bump
 
 Preview a patch release without modifying files:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -162,7 +162,8 @@ seal bump [OPTIONS] <VERSION>
 <li><code>auto</code>:  Enables colored output only when the output is going to a terminal or TTY with support</li>
 <li><code>always</code>:  Enables colored output regardless of the detected environment</li>
 <li><code>never</code>:  Disables colored output</li>
-</ul></dd><dt id="seal-bump--dry-run"><a href="#seal-bump--dry-run"><code>--dry-run</code></a></dt><dd><p>Show what would be done without making any changes</p>
+</ul></dd><dt id="seal-bump--dry-run"><a href="#seal-bump--dry-run"><code>--dry-run</code></a></dt><dd><p>Run preflight checks and show what would be done without making changes</p>
+</dd><dt id="seal-bump--force"><a href="#seal-bump--force"><code>--force</code></a></dt><dd><p>Bypass the clean working tree and index check</p>
 </dd><dt id="seal-bump--help"><a href="#seal-bump--help"><code>--help</code></a>, <code>-h</code></dt><dd><p>Display the concise help for this command</p>
 </dd><dt id="seal-bump--no-changelog"><a href="#seal-bump--no-changelog"><code>--no-changelog</code></a></dt><dd><p>Skip generating or updating the changelog</p>
 </dd><dt id="seal-bump--no-progress"><a href="#seal-bump--no-progress"><code>--no-progress</code></a></dt><dd><p>Hide all progress outputs.</p>

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -247,8 +247,9 @@ Behavior when a pre-commit command fails.
 <span id="release_pre-commit-commands"></span>
 #### [`pre-commit-commands`](#release_pre-commit-commands)
 
-Commands to run before committing. These run after `git add -A` and before `git commit`.
-A second `git add -A` is run after these commands to stage any changes they make.
+Commands to run before committing. A non-empty list requires `commit-message`. These run
+after `git add -A` and before `git commit`. A second `git add -A` is run after these commands
+to stage any changes they make.
 
 **Default value**: `[]`
 
@@ -260,6 +261,7 @@ A second `git add -A` is run after these commands to stage any changes they make
 
     ```toml
     [release]
+    commit-message = "Release {version}"
     pre-commit-commands = ["cargo fmt", "npm run lint:fix"]
     ```
 

--- a/docs/usage/bumping_versions.md
+++ b/docs/usage/bumping_versions.md
@@ -26,6 +26,9 @@ seal bump patch --dry-run
 seal bump patch
 ```
 
+Commit the configuration and version files before running either command; Seal requires a clean
+working tree and index by default.
+
 Seal replaces `0.0.1` with `0.0.2` in `README.md` and updates `current-version` in `seal.toml`.
 
 ## Structured and Targeted Replacements
@@ -70,6 +73,17 @@ seal bump 2.0.0-rc.1
 ```
 
 An explicit version must be newer than `current-version`.
+
+## Git Preflight Checks
+
+Before applying changes, Seal verifies that the working tree and index are clean. When a release
+branch is configured, its resolved name must be valid and absent locally and on `origin` when
+that remote exists. `push = true` requires `origin`, and pull-request creation requires GitHub
+authentication. A non-empty `pre-commit-commands` list requires `commit-message`.
+
+`--dry-run` runs and reports the same checks. `--force` skips only the clean working tree and index
+check; branch, remote, configuration, and authentication failures remain errors. Because commit
+workflows use `git add -A`, forcing a dirty tree can include existing changes in the release commit.
 
 ## Release Branches and Commits
 


### PR DESCRIPTION
## Summary

Add a bump preflight that rejects dirty Git state, invalid or colliding release branches, unavailable push targets, unauthenticated pull-request creation, and invalid pre-commit configuration before mutation. Dry runs report the same checks, while `--force` skips only the clean working tree and index check.

Fixes #80.

## Test Plan

Verified with `cargo nextest run --all-features`, strict workspace Clippy, and `uvx prek run -a`.