### PR TITLE
Improve contributor guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,73 +1,142 @@
 # Seal Repository
 
-Seal is a Rust workspace for a release-management CLI. Read `CONTRIBUTING.md` before changing
-files; it contains the current crate map, setup commands, documentation workflow, and release
-process.
+This repository contains Seal, a release-management CLI implemented as a Rust
+workspace. Rust crates use the `seal_*` naming convention and live under
+`crates/`.
+
+The `seal` binary parses CLI arguments, resolves project configuration, and
+delegates version, changelog, GitHub, and file operations to focused library
+crates.
+
+## Code Review Rules
+
+When reviewing a branch or pull request, be deliberately nitpicky. Report not
+only bugs and regressions, but also architectural and maintenance risks, weak
+test coverage, unclear code, unnecessary complexity, and meaningful style or
+consistency issues. Order findings by severity, cite files and lines, and
+distinguish blockers from non-blocking improvements. Number each review point
+for easy reference in subsequent review discussion.
 
 ## Running Tests
 
-Run the test suite with nextest:
+Run all tests:
 
 ```sh
 cargo nextest run --all-features
 ```
 
-Use `cargo test` if nextest is unavailable. Prefer a package or test filter while iterating:
+Run tests for a specific crate:
 
 ```sh
 cargo nextest run -p seal
 ```
 
-Run the CLI from the workspace root:
+Run a specific test:
 
 ```sh
-cargo run -p seal -- --help
+cargo nextest run -p seal test_name
 ```
 
-Run Clippy with the same strictness as CI:
+### Fallback Without Nextest
+
+Use `cargo test` with the same arguments when `cargo-nextest` is unavailable.
+
+### Snapshot Updates
+
+After running tests, always review every snapshot that was added or updated.
+Check for pending `.snap.new` files if affected tests use snapshots.
+
+Do not edit snapshot files or inline snapshot bodies manually. Regenerate them
+by running the relevant tests, then review the generated diff. Do not accept
+unrelated snapshot changes.
+
+## Running Clippy
 
 ```sh
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 ```
 
-Run `uvx prek run -a` at the end of every task. During iteration, use
-`uvx prek run --files <path1> <path2>` with every changed file so hook runs do not depend on staged
-state.
+## Running Debug Builds
 
-## Snapshots and Generated Files
+Use debug builds, not `--release`, while developing. Release builds lack debug
+assertions and take longer to compile.
 
-Prefer integration tests under `crates/seal/tests/it/` when behavior crosses crate or CLI
-boundaries. Command integration tests should use the existing `seal_snapshot!` helper.
+Run Seal from the workspace root:
 
-Review snapshot changes before accepting them and check for pending `.snap.new` files before
-finishing.
+```sh
+cargo run -p seal -- --help
+cargo run -p seal -- self version
+```
 
-Run the following command after changing configuration options, CLI arguments, or anything else
-that feeds the generated reference pages under `docs/reference/`:
+## Generated Documentation
+
+The CLI and configuration references under `docs/reference/` are generated.
+
+After changing configuration options, CLI arguments, or their reference
+documentation, regenerate all references:
 
 ```sh
 cargo dev generate-all
 ```
 
-Do not hand-edit generated reference pages.
+Review the generated diff before committing it. Do not edit generated
+reference pages manually.
+
+## GitHub Actions
+
+Actions must be pinned to full commit SHAs. After changing a workflow, run:
+
+```sh
+pinact run
+```
 
 ## Development Guidelines
 
-- Test every behavior change. If the relevant tests were not run, the change is not done.
-- Look for existing utilities and neighboring patterns before writing new code.
-- Keep visibility narrow unless another workspace crate genuinely needs the item.
-- Keep Rust imports at the top of the file rather than inside functions.
-- Avoid `panic!`, `unreachable!`, `.unwrap()`, unsafe code, and Clippy ignores. Encode constraints in
-  the type system instead.
-- Prefer `if let` for fallibility and let chains over nested `if let` statements when clearer.
-- Prefer `#[expect(...)]` over `#[allow(...)]` when a lint must be suppressed.
-- Use comments for invariants and unusual decisions, not to narrate code.
-- Route command output through `Printer` and diagnostics through `tracing`; do not add direct print
-  calls to command handlers.
-- Consider whether a change needs a guide or regenerated reference page. New flags, changed
-  defaults, configuration changes, and user-visible workflows usually do.
+- All significant changes must be tested. Add or update focused tests for
+  behavior changes when existing coverage does not establish the intended
+  behavior.
+- Look for an existing test file before creating a new one.
+- Get the relevant tests to pass. If the tests were not run, the change is not
+  done.
+- Follow existing code style. Check neighboring files for patterns.
+- Prefer integration tests under `crates/seal/tests/it/` when behavior crosses
+  crate or CLI boundaries. Command integration tests should use the existing
+  `seal_snapshot!` helper.
+- Keep changes focused. Do not expand the task to unrelated issues.
+- Before writing significant new code, look for existing utilities or
+  mechanisms that solve the problem. Prefer fixing the underlying
+  architectural problem over adding a localized workaround. Ask for guidance
+  when the larger change is unclear.
+- Prefer narrow visibility because this workspace is generally its own
+  consumer. Do not add workarounds solely to avoid `pub`; make an item public
+  when another workspace crate needs it and that produces the cleaner design.
+- Keep Rust imports at the top of the file, never locally inside functions.
+- Avoid `panic!`, `unreachable!`, `.unwrap()`, unsafe code, and Clippy ignores.
+  Encode constraints in the type system.
+- Prefer `if let` for fallibility. Prefer let chains over nested `if let`
+  statements when they reduce indentation.
+- If a Clippy lint must be suppressed, prefer `#[expect(...)]` over
+  `#[allow(...)]`. Delete unused code instead of suppressing dead-code
+  warnings.
+- Prefer short imports over fully qualified paths.
+- Do not use comments to narrate code. Use them to explain invariants and why
+  unusual decisions were made. Prefer plain language that makes sense without
+  prior context.
+- Avoid redundant comments and section separators in tests. Prefer function
+  comments over inline comments.
+- Route command output through `Printer` and diagnostics through `tracing`.
+  Do not print directly from command handlers.
+- Consider whether public APIs, flags, defaults, configuration, or user-visible
+  workflows require documentation updates.
+- Run `uvx prek run --files <path1> <path2>` during iteration and pass every
+  changed file. Run `uvx prek run -a` before finishing.
 
 ## Pull Requests
 
-Use the pull request template and add relevant labels. Write the description in concise prose
-paragraphs, with code examples only when they help the reviewer.
+Use the pull request template and add relevant labels. Keep the summary and
+test plan concise. Write descriptions as prose, not bullet lists or
+checklists. Explain what changed and why; include implementation details only
+when reviewers need them.
+
+Use a descriptive one-line commit subject by default. Never add an AI tool as
+an author or co-author.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,134 +1,167 @@
 # Contributing to Seal
 
-Contributions of all kinds are welcome. Open an
-[issue](https://github.com/MatthewMckee4/seal/issues/new) for bugs, feature ideas, or documentation
-improvements.
+Welcome, and thanks for contributing to Seal.
 
-Small fixes can go straight to a pull request. For larger changes, open or comment on an issue
-first so the intended behavior is clear before implementation starts.
+## Finding Ways to Help
 
-Issues suitable for a first contribution are labelled
-[`good first issue`](https://github.com/MatthewMckee4/seal/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
-Issues where help is especially useful are labelled
-[`help wanted`](https://github.com/MatthewMckee4/seal/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22).
+[`good first issue`](https://github.com/MatthewMckee4/seal/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
+issues are ready for new contributors.
+[`help wanted`](https://github.com/MatthewMckee4/seal/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
+issues are good candidates when you already know the codebase.
 
-## Architecture
+Comment before starting work so another contributor does not duplicate it and
+the maintainer can confirm the issue is current. Discuss larger changes and
+new features before opening a pull request; they can affect Seal's scope and
+long-term maintenance burden.
 
-Seal is a Cargo workspace. The `seal` binary parses CLI arguments, resolves project configuration,
-and delegates version, changelog, GitHub, and file operations to focused library crates.
+Use [GitHub issues](https://github.com/MatthewMckee4/seal/issues/new) for bug
+reports, feature proposals, and documentation problems.
 
-The executable and core domain crates are:
+## The Basics
 
-- `seal` — CLI entry point, command handlers, global settings, and user-facing output.
-- `seal_cli` — shared Clap argument and command definitions.
-- `seal_project` — `seal.toml` parsing, validation, project discovery, and workspace members.
-- `seal_bump` — semantic-version calculation and version-file updates.
-- `seal_changelog` — changelog generation, updates, and release-body metadata.
-- `seal_github` — GitHub API access and repository remote parsing.
-- `seal_file_change` — file-change previews, diffs, and application.
-- `seal_command` — Git and configured subprocess execution.
+### Prerequisites
 
-Supporting crates are:
+Seal development requires the
+[Rust toolchain](https://www.rust-lang.org/tools/install). Rustup will use the
+repository's pinned toolchain.
 
-- `seal_fs` — paths relative to the project root.
-- `seal_logging` — tracing output formatting.
-- `seal_terminal` — terminal sizing.
-- `seal_version` — the released CLI version.
-- `seal_options_metadata` and `seal_macros` — metadata used to generate the configuration reference.
-- `seal_dev` — developer commands that generate the CLI and configuration references.
-
-Command handlers should send normal output through the `Printer` abstraction in
-`crates/seal/src/printer.rs`. Use `tracing` for diagnostics controlled by `-v`; do not print
-directly from handlers.
-
-## Prerequisites
-
-Install Rust with [rustup](https://rustup.rs/). Rustup will use the repository's pinned toolchain.
-
-[nextest](https://nexte.st/) is recommended for the test suite:
+We recommend [nextest](https://nexte.st/) for faster Rust test runs:
 
 ```sh
 cargo install cargo-nextest --locked
 ```
 
-You can optionally install [prek](https://prek.j178.dev/) to run repository checks before each
-commit:
+Install the optional repository hooks with:
 
 ```sh
-uv tool install prek
-prek install
+uvx prek install
 ```
 
-Build the workspace from the repository root:
+### Development
+
+Build the workspace:
 
 ```sh
 cargo build --workspace
 ```
 
-## Development
-
-Run the development CLI with Cargo:
+Run Seal from the repository root with a debug build:
 
 ```sh
 cargo run -p seal -- --help
 cargo run -p seal -- self version
 ```
 
-Run the full test suite with nextest:
+### Project Structure
+
+The `seal` binary parses CLI arguments, resolves project configuration, and
+delegates work to focused library crates. All Rust crates live under
+`crates/`:
+
+- `seal` contains the CLI entry point, command handlers, global settings, and
+  user-facing output.
+- `seal_cli` contains shared Clap argument and command definitions.
+- `seal_project` handles `seal.toml` parsing, validation, project discovery,
+  and workspace members.
+- `seal_bump` calculates semantic versions and updates version files.
+- `seal_changelog` generates changelogs and release metadata.
+- `seal_github` provides GitHub API access and repository remote parsing.
+- `seal_file_change` handles file-change previews, diffs, and application.
+- `seal_command` runs Git and configured subprocesses.
+- `seal_fs`, `seal_logging`, `seal_terminal`, and `seal_version` provide shared
+  infrastructure.
+- `seal_options_metadata` and `seal_macros` support generated configuration
+  metadata.
+- `seal_dev` contains documentation generators.
+
+Documentation lives under `docs/`, and CLI integration tests live under
+`crates/seal/tests/it/`.
+
+Command handlers send normal output through `Printer`. Diagnostics controlled
+by `-v` use `tracing`.
+
+## Testing
+
+Run the full suite:
 
 ```sh
 cargo nextest run --all-features
 ```
 
-Use `cargo test` if nextest is unavailable. Pass arguments directly for focused iteration:
+Pass standard `cargo nextest` arguments for focused runs:
 
 ```sh
 cargo nextest run -p seal
+cargo nextest run -p seal test_name
 ```
 
-CLI integration tests live under
-`crates/seal/tests/it/` and use the `seal_snapshot!` helper.
+Use `cargo test` with the same arguments when nextest is unavailable.
 
-After updating snapshots, review the changes before accepting them. For the interactive review
-workflow, install [`cargo-insta`](https://insta.rs/docs/cli/), run the relevant test, then run:
-
-```sh
-cargo insta review
-```
-
-Before opening a pull request, run the relevant tests and the full validation sweep:
+Before opening a pull request, run relevant focused tests and the validation
+sweep:
 
 ```sh
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 uvx prek run -a
 ```
 
+GitHub Actions runs tests on Linux, macOS, and Windows. Platform-specific
+behavior should have focused coverage where practical.
+
+### Snapshot Tests
+
+Prefer integration tests when behavior crosses crate or CLI boundaries.
+Command integration tests should use the existing `seal_snapshot!` helper so
+diagnostics and exit behavior remain visible.
+
+Review every snapshot change before accepting it. Check for unexpected
+`.snap.new` files before finishing, and never include unrelated snapshot
+updates in a pull request.
+
 ## Documentation
 
-Seal uses [Zensical](https://zensical.org/) for its documentation site. Prepare the generated home
-page and build the site with:
+Seal uses [Zensical](https://zensical.org/) for its documentation site. Prepare
+the generated home page and build the site with:
 
 ```sh
 uv run --script scripts/prepare_docs.py
 uv run --isolated --with-requirements docs/requirements.txt zensical build
 ```
 
-Use `zensical serve` instead of `zensical build` in the second command for a local development
-server.
-
-The CLI and configuration reference pages are generated. After changing CLI arguments,
-configuration fields, defaults, or their source documentation, run:
+Run the documentation generator after changing configuration options, CLI
+arguments, or their source documentation:
 
 ```sh
 cargo dev generate-all
 ```
 
-Do not edit `docs/reference/cli.md` or `docs/reference/configuration.md` by hand.
+Files under `docs/reference/` are generated. Do not edit them manually; review
+the generated diff before committing it.
+
+## Opening a Pull Request
+
+Use the pull request template, link relevant issues, and add labels that match
+the affected area. Keep the pull request in draft while substantial work
+remains.
+
+### Summary
+
+Explain what changed and why in concise prose. Include implementation details
+only when reviewers need them to understand the design or trade-offs.
+
+### Test Plan
+
+State what you verified in one short sentence. If CI is the only remaining
+validation, write `ci`.
+
+Keep commits focused and use descriptive one-line subjects. Do not mix
+formatter churn or unrelated cleanup with the change.
 
 ## Release Process
 
-Run the `Prepare release` workflow with the version bump to perform, such as `alpha` or an
-explicit version. The workflow runs `seal bump <version>` and opens the release pull request.
+Run the `Prepare release` workflow with the version bump to perform, such as
+`alpha` or an explicit version. The workflow runs `seal bump <version>` and
+opens the release pull request.
 
 To prepare a release locally, run:
 
@@ -136,15 +169,18 @@ To prepare a release locally, run:
 cargo run -p seal -- bump <version>
 ```
 
-Seal creates the release branch, commits and pushes the changes, and opens a pull request. Review
-and merge it, then run the
-[release workflow](https://github.com/MatthewMckee4/seal/actions/workflows/release.yml) with the
-version tag without a leading `v`; the workflow builds artifacts, creates the GitHub release, and
-publishes the documentation.
+Seal creates the release branch, commits and pushes the changes, and opens a
+pull request. Review and merge it, then run the
+[release workflow](https://github.com/MatthewMckee4/seal/actions/workflows/release.yml)
+with the version tag without a leading `v`; it builds artifacts, creates the
+GitHub release, and publishes the documentation.
 
-When changing GitHub Actions, run [`pinact`](https://github.com/suzuki-shunsuke/pinact) before
-opening the pull request:
+## GitHub Actions
+
+Actions must be pinned to full commit SHAs. After editing a workflow, run:
 
 ```sh
 pinact run
 ```
+
+Review generated workflow changes before committing them.


### PR DESCRIPTION
## Summary

Restructure `AGENTS.md` and `CONTRIBUTING.md` around clearer development workflows while keeping Seal-specific commands and a compact project map. Contributor guidance now separates agent rules from human onboarding, testing, documentation, pull request, release, and workflow instructions.

## Test Plan

`uvx prek run -a`