### PR TITLE
Add release preparation workflow

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,43 @@
+name: Prepare release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version bump to perform (e.g., alpha or 1.2.3)"
+        required: true
+        default: alpha
+        type: string
+
+permissions: {}
+
+jobs:
+  prepare-release:
+    name: Prepare release
+    if: github.repository == 'MatthewMckee4/seal'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: true
+
+      - name: Install seal
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/MatthewMckee4/seal/releases/download/0.0.1-alpha.6/seal-installer.sh | sh
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version and create pull request
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: printf 'y\n' | seal bump "$VERSION"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,13 +127,17 @@ Do not edit `docs/reference/cli.md` or `docs/reference/configuration.md` by hand
 
 ## Release Process
 
-Releases are automated and are only performed by maintainers. Use Seal itself to prepare one:
+Run the `Prepare release` workflow with the version bump to perform, such as `alpha` or an
+explicit version. The workflow runs `seal bump <version>` and opens the release pull request.
+
+To prepare a release locally, run:
 
 ```sh
 cargo run -p seal -- bump <version>
 ```
 
-Review and merge the generated release pull request. Then run the
+Seal creates the release branch, commits and pushes the changes, and opens a pull request. Review
+and merge it, then run the
 [release workflow](https://github.com/MatthewMckee4/seal/actions/workflows/release.yml) with the
 version tag without a leading `v`; the workflow builds artifacts, creates the GitHub release, and
 publishes the documentation.

--- a/seal.toml
+++ b/seal.toml
@@ -13,6 +13,12 @@ branch-name = "release/v{version}"
 push = true
 confirm = true
 
+[release.pull-request]
+title = "Release v{version}"
+body = "Prepare release v{version}."
+base = "main"
+draft = false
+
 [changelog.section-labels]
 "Bug Fixes" = ["bug"]
 "Changelog" = ["changelog"]


### PR DESCRIPTION
## Summary

Adds a manual release preparation workflow that runs the current Seal release with scoped credentials to push a release branch and open its pull request. Enables pull-request creation in `seal.toml` and documents both automated and local release preparation.

## Test Plan

`cargo run -p seal -- validate config`, `pinact run`, and `uvx prek run -a`