### PR TITLE
Preview pull request details before confirmation

### DIFF
--- a/crates/seal/src/commands/bump.rs
+++ b/crates/seal/src/commands/bump.rs
@@ -213,20 +213,7 @@ pub async fn bump(args: &BumpArgs, printer: Printer) -> Result<ExitStatus> {
         }
     }
 
-    if args.dry_run {
-        if let Some(pull_request) = &pull_request {
-            writeln!(stdout, "Pull request:")?;
-            writeln!(stdout, "  Title: {}", pull_request.title)?;
-            writeln!(stdout, "  Base: {}", pull_request.base)?;
-            writeln!(stdout, "  Draft: {}", pull_request.draft)?;
-            writeln!(stdout)?;
-        }
-
-        writeln!(stdout, "Dry run complete. No changes made.")?;
-        return Ok(ExitStatus::Success);
-    }
-
-    if !commands.is_empty() {
+    if !args.dry_run && !commands.is_empty() {
         writeln!(stdout, "Commands to be executed:")?;
 
         for tagged in &commands {
@@ -234,6 +221,32 @@ pub async fn bump(args: &BumpArgs, printer: Printer) -> Result<ExitStatus> {
         }
 
         writeln!(stdout)?;
+    }
+
+    if let Some(pull_request) = &pull_request {
+        writeln!(stdout, "Pull request:")?;
+        writeln!(stdout, "  Title: {}", pull_request.title)?;
+        writeln!(stdout, "  Head: {}", pull_request.head)?;
+        writeln!(stdout, "  Base: {}", pull_request.base)?;
+        writeln!(stdout, "  Draft: {}", pull_request.draft)?;
+        if pull_request.body.is_empty() {
+            writeln!(stdout, "  Body: (empty)")?;
+        } else {
+            writeln!(stdout, "  Body:")?;
+            for line in pull_request.body.lines() {
+                if line.is_empty() {
+                    writeln!(stdout)?;
+                } else {
+                    writeln!(stdout, "    {line}")?;
+                }
+            }
+        }
+        writeln!(stdout)?;
+    }
+
+    if args.dry_run {
+        writeln!(stdout, "Dry run complete. No changes made.")?;
+        return Ok(ExitStatus::Success);
     }
 
     if release_config.confirm {

--- a/crates/seal/tests/it/bump/mod.rs
+++ b/crates/seal/tests/it/bump/mod.rs
@@ -1184,6 +1184,13 @@ push = true
       `git commit -m Release v1.2.4`
       `git push origin release/v1.2.4`
 
+    Pull request:
+      Title: Release v1.2.4
+      Head: release/v1.2.4
+      Base: main
+      Draft: false
+      Body: (empty)
+
     Proceed with these changes? (y/n):
     Updating files...
     Executing command: `git checkout -b release/v1.2.4`
@@ -1276,6 +1283,13 @@ confirm = false
       `git commit -m Release v1.2.4`
       `git push origin release/v1.2.4`
 
+    Pull request:
+      Title: Release v1.2.4
+      Head: release/v1.2.4
+      Base: main
+      Draft: false
+      Body: (empty)
+
 
     ----- stderr -----
     error: GitHub authentication is required; set GITHUB_TOKEN or GH_TOKEN
@@ -1353,8 +1367,10 @@ push = true
 
     Pull request:
       Title: Release v1.2.4
+      Head: release/v1.2.4
       Base: main
       Draft: false
+      Body: (empty)
 
     Dry run complete. No changes made.
 
@@ -1392,6 +1408,7 @@ branch-name = "release/v{version}"
 push = true
 [release.pull-request]
 title = "Ship {version}"
+body = "Prepare release {version}.\n\nReview before merging."
 base = "stable"
 draft = true
 "#,
@@ -1421,8 +1438,13 @@ draft = true
 
     Pull request:
       Title: Ship 1.2.4
+      Head: release/v1.2.4
       Base: stable
       Draft: true
+      Body:
+        Prepare release 1.2.4.
+
+        Review before merging.
 
     Dry run complete. No changes made.
 
@@ -1489,6 +1511,13 @@ confirm = false
       `git add -A`
       `git commit -m Release v1.2.4`
       `git push origin release/v1.2.4`
+
+    Pull request:
+      Title: Release v1.2.4
+      Head: release/v1.2.4
+      Base: main
+      Draft: false
+      Body: (empty)
 
     Updating files...
     Executing command: `git checkout -b release/v1.2.4`

--- a/docs/usage/bumping_versions.md
+++ b/docs/usage/bumping_versions.md
@@ -109,6 +109,9 @@ The table itself enables pull-request creation and requires `commit-message`, `b
 changelog section body or an empty string, `base` defaults to the branch from which the release
 branch was created, and `draft` defaults to `false`. The title and body support `{version}`.
 
+Before confirmation, Seal prints the resolved title, body, head and base branches, and draft state
+alongside the Git commands it will run.
+
 Seal updates the title, body, and draft state of an existing open pull request with the same head
 and base branches instead of creating a duplicate. Creating or updating a pull request requires
 `GITHUB_TOKEN` or `GH_TOKEN` with permission to write pull requests in the repository.


### PR DESCRIPTION
## Summary

Display the resolved pull request title, head and base branches, draft state, and body beside the Git command preview before confirmation. The same preview remains available during dry runs, with empty bodies shown explicitly.

## Test Plan

`cargo nextest run --all-features`, the documentation build, and `uvx prek run -a`.