### PR TITLE
Exclude release workflow from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    exclude-paths:
+      - ".github/workflows/release.yml"
     labels:
       - "dependencies"
     schedule:


### PR DESCRIPTION
## Summary

Exclude `.github/workflows/release.yml` from GitHub Actions version updates. Release workflow remains manually maintained, preventing grouped Dependabot PRs such as #117 from changing it.

## Test Plan

`uvx prek run -a`