### PR TITLE
Detect every missing version file

### DIFF
--- a/crates/seal/tests/it/bump/custom_formats.rs
+++ b/crates/seal/tests/it/bump/custom_formats.rs
@@ -1347,6 +1347,40 @@ version-files = ["VERSION"]
 }
 
 #[test]
+fn bump_glob_not_found_after_matching_version_file() {
+    let context = TestContext::new();
+    context
+        .seal_toml(
+            r#"
+[release]
+current-version = "1.0.0"
+commit-message = "Release {version}"
+branch-name = "release/{version}"
+
+version-files = ["README.md", "VERSION"]
+"#,
+        )
+        .init_git();
+
+    context
+        .root
+        .child("README.md")
+        .write_str("# Version 1.0.0")
+        .unwrap();
+
+    seal_snapshot!(context.filters(), context.command().arg("bump").arg("major"), @r"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+    Bumping version from 1.0.0 to 2.0.0
+
+
+    ----- stderr -----
+    error: No files found for path or glob `VERSION`
+    ");
+}
+
+#[test]
 fn bump_glob_not_found_just_path() {
     let context = TestContext::new();
     context

--- a/crates/seal_bump/src/bump.rs
+++ b/crates/seal_bump/src/bump.rs
@@ -3,7 +3,7 @@ use glob::glob;
 use seal_file_change::{FileChange, FileChanges, make_absolute};
 use seal_fs::FileResolver;
 use seal_project::{VersionFile, VersionFileTextFormat};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::Version;
 
@@ -43,15 +43,13 @@ pub fn calculate_version_file_changes(
     let new_version_str = new_version.to_string();
 
     for version_file in version_files {
-        let previous_change_count = changes.len();
-
         match version_file {
             VersionFile::Text {
                 path,
                 format,
                 field,
             } => {
-                for path in glob(path)?.filter_map(Result::ok) {
+                for path in version_file_paths(path)? {
                     let absolute_path = make_absolute(root, &path);
                     let old_content = fs_err::read_to_string(&path)?;
 
@@ -109,13 +107,9 @@ pub fn calculate_version_file_changes(
 
                     changes.push(FileChange::new(absolute_path, old_content, new_content));
                 }
-
-                if changes.len() == previous_change_count {
-                    anyhow::bail!("No files found for path or glob `{path}`");
-                }
             }
             VersionFile::Search { path, search } => {
-                for path in glob(path)?.filter_map(Result::ok) {
+                for path in version_file_paths(path)? {
                     let old_content = fs_err::read_to_string(&path)?;
 
                     let search_with_current = search.replace("{version}", current_version);
@@ -135,13 +129,9 @@ pub fn calculate_version_file_changes(
                         new_content,
                     ));
                 }
-
-                if changes.len() == previous_change_count {
-                    anyhow::bail!("No files found for path or glob `{path}`");
-                }
             }
             VersionFile::JustPath { path } | VersionFile::Simple(path) => {
-                for path in glob(path)?.filter_map(Result::ok) {
+                for path in version_file_paths(path)? {
                     let absolute_path = make_absolute(root, &path);
                     let old_content = fs_err::read_to_string(&path)?;
 
@@ -153,10 +143,6 @@ pub fn calculate_version_file_changes(
                     )?;
 
                     changes.push(FileChange::new(absolute_path, old_content, new_content));
-                }
-
-                if changes.len() == previous_change_count {
-                    anyhow::bail!("No files found for path or glob `{path}`");
                 }
             }
         }
@@ -183,6 +169,16 @@ pub fn calculate_version_file_changes(
     ));
 
     Ok(FileChanges::new(changes))
+}
+
+fn version_file_paths(path: &str) -> Result<Vec<PathBuf>> {
+    let paths = glob(path)?.collect::<std::result::Result<Vec<_>, _>>()?;
+
+    if paths.is_empty() {
+        anyhow::bail!("No files found for path or glob `{path}`");
+    }
+
+    Ok(paths)
 }
 
 fn exact_version_replacement(

--- a/crates/seal_bump/src/bump.rs
+++ b/crates/seal_bump/src/bump.rs
@@ -43,6 +43,8 @@ pub fn calculate_version_file_changes(
     let new_version_str = new_version.to_string();
 
     for version_file in version_files {
+        let previous_change_count = changes.len();
+
         match version_file {
             VersionFile::Text {
                 path,
@@ -108,7 +110,7 @@ pub fn calculate_version_file_changes(
                     changes.push(FileChange::new(absolute_path, old_content, new_content));
                 }
 
-                if changes.is_empty() {
+                if changes.len() == previous_change_count {
                     anyhow::bail!("No files found for path or glob `{path}`");
                 }
             }
@@ -134,7 +136,7 @@ pub fn calculate_version_file_changes(
                     ));
                 }
 
-                if changes.is_empty() {
+                if changes.len() == previous_change_count {
                     anyhow::bail!("No files found for path or glob `{path}`");
                 }
             }
@@ -153,7 +155,7 @@ pub fn calculate_version_file_changes(
                     changes.push(FileChange::new(absolute_path, old_content, new_content));
                 }
 
-                if changes.is_empty() {
+                if changes.len() == previous_change_count {
                     anyhow::bail!("No files found for path or glob `{path}`");
                 }
             }


### PR DESCRIPTION
## Summary

Validate each configured version file independently so a missing entry cannot be hidden by an earlier matching file. The previous check inspected the accumulated change list instead of matches for the current entry.

Closes #118

## Test Plan

`cargo nextest run --all-features`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `uvx prek run -a`.